### PR TITLE
Suomi NPP Chooser fix

### DIFF
--- a/edu/wisc/ssec/mcidasv/chooser/SuomiNPPChooser.java
+++ b/edu/wisc/ssec/mcidasv/chooser/SuomiNPPChooser.java
@@ -149,7 +149,20 @@ public class SuomiNPPChooser extends FileChooser {
                     Date dE = null;
                     try {
 						dS = sdf.parse(dateStr + timeStrStart);
-						dE = sdf.parse(dateStr + timeStrEnd);
+						// due to nature of Suomi NPP file name encoding, we need a special
+						// check here - end time CAN roll over to next day, while day part 
+						// does not change.  if this happens, we tweak the date string
+						String endDateStr = dateStr;
+						String startHour = timeStrStart.substring(0, 2);
+						String endHour = timeStrEnd.substring(0, 2);
+						if ((startHour.equals("23")) && (endHour.equals("00"))) {
+							// temporarily convert date to integer, increment, convert back
+							int tmpDate = Integer.parseInt(dateStr);
+							tmpDate++;
+							endDateStr = "" + tmpDate;
+							logger.info("Granule time spanning days case handled ok...");
+						}
+						dE = sdf.parse(endDateStr + timeStrEnd);
 					} catch (ParseException e) {
 						logger.error("Not recognized as valid Suomi NPP file name: " + fileName);
 						testResult = false;


### PR DESCRIPTION
The test which ensures granules for any single selection are contiguous (consecutive) was failing for the odd case when a single granule spans days.  Example file:

SVDNB_npp_d20121224_t2359027_e0000250_b06010_c20121225062527967541_noaa_ops.h5

Note how start time t2359 and end time e0000 span days.  
