### PR TITLE
Don't build the Advanced prefs tab if already built... Tentative fix for...

### DIFF
--- a/edu/wisc/ssec/mcidasv/McIdasPreferenceManager.java
+++ b/edu/wisc/ssec/mcidasv/McIdasPreferenceManager.java
@@ -639,7 +639,13 @@ public class McIdasPreferenceManager extends IdvPreferenceManager implements Lis
         addFormatDataPreferences();
 
         // Advanced
-        addAdvancedPreferences();
+        if (!labelSet.contains(Constants.PREF_LIST_ADVANCED)) {
+        	// due to issue with MemoryOption.getTextComponent, we don't
+        	// want to do this again if Advanced tab is already built.
+        	// (the heap size text field will disappear on second opening
+        	//  of McV preferences window!)
+        	addAdvancedPreferences();
+        }
     }
 
     /**


### PR DESCRIPTION
... [306]

Currently, McIdasPreferenceManager completely rebuilds the "Advanced" tab every time the Preferences window is opened, yet doesn't actually use the newly built components in the resulting display (it finally punts at line 375 in the "add" method).

Somehow this causes a problem with the text field for the heap size option. When the JPanel referenced by "textPanel" changes (see "MemoryOption.getTextComponent") after the Preferences window is opened the second time, the component actually in the display is left hanging on to the "original" one. I haven't been able to convince myself exactly how this causes the problem that it does, but I'm pretty sure it's at the root of the issue. (To confirm this...you can put a hack in MemoryOption.getTextComponent that immediately returns an empty JPanel in the event that textPanel has already been built, and the bug is solved!)

Regardless, I think this pull request fixes the problem (don't build the Advanced tab if we don't need to...basically this just stops code from running unnecessarily), and I haven't been able to see any side effects.
