### PR TITLE
Fixes for ADDE bundle resave problem [925]

### DIFF
--- a/edu/wisc/ssec/mcidasv/data/adde/AddeImageParameterDataSource.java
+++ b/edu/wisc/ssec/mcidasv/data/adde/AddeImageParameterDataSource.java
@@ -461,7 +461,7 @@ public class AddeImageParameterDataSource extends AddeImageDataSource {
             checkboxes.add(cbx);
             DataCategory dc = dataChoice.getDisplayCategory();
             if (dc == null) {
-            	dc = DataCategory.createCategory(DataCategory.CATEGORY_IMAGE);
+                dc = DataCategory.createCategory(DataCategory.CATEGORY_IMAGE);
             }
             List comps = (List)catMap.get(dc);
             if (comps == null) {
@@ -574,29 +574,29 @@ public class AddeImageParameterDataSource extends AddeImageDataSource {
             logger.trace("bandinfo.getUnit={} selection props={}", bandInfo.getPreferredUnit(), selectionProperties);
             for (AddeImageDescriptor descriptor : descriptors) {
 //                AddeImageInfo aii = (AddeImageInfo)descriptor.getImageInfo().clone();
-            	if (!isFromFile(descriptor)) {
-	                String src = descriptor.getSource();
-	                logger.trace("src before={}", src);
-	                src = replaceKey(src, AddeImageURL.KEY_UNIT, bandInfo.getPreferredUnit());
-	                if (selectionProperties.containsKey(AddeImageURL.KEY_PLACE)) {
-	                    src = replaceKey(src, AddeImageURL.KEY_PLACE, selectionProperties.get(AddeImageURL.KEY_PLACE));
-	                }
-	                if (selectionProperties.containsKey(AddeImageURL.KEY_LATLON)) {
-	                    src = replaceKey(src, AddeImageURL.KEY_LINEELE, AddeImageURL.KEY_LATLON, selectionProperties.get(AddeImageURL.KEY_LATLON));
-	                }
-	                if (selectionProperties.containsKey(AddeImageURL.KEY_LINEELE)) {
-	                    src = removeKey(src, AddeImageURL.KEY_LATLON);
-	                    src = replaceKey(src, AddeImageURL.KEY_LINEELE, selectionProperties.get(AddeImageURL.KEY_LINEELE));
-	                }
-	                if (selectionProperties.containsKey(AddeImageURL.KEY_MAG)) {
-	                    src = replaceKey(src, AddeImageURL.KEY_MAG, selectionProperties.get(AddeImageURL.KEY_MAG));
-	                }
-	                if (selectionProperties.containsKey(AddeImageURL.KEY_SIZE)) {
-	                    src = replaceKey(src, AddeImageURL.KEY_SIZE, selectionProperties.get(AddeImageURL.KEY_SIZE));
-	                }
-	                logger.trace("src after={}", src);
-	                descriptor.setSource(src);
-            	}
+                if (!isFromFile(descriptor)) {
+                    String src = descriptor.getSource();
+                    logger.trace("src before={}", src);
+                    src = replaceKey(src, AddeImageURL.KEY_UNIT, bandInfo.getPreferredUnit());
+                    if (selectionProperties.containsKey(AddeImageURL.KEY_PLACE)) {
+                        src = replaceKey(src, AddeImageURL.KEY_PLACE, selectionProperties.get(AddeImageURL.KEY_PLACE));
+                    }
+                    if (selectionProperties.containsKey(AddeImageURL.KEY_LATLON)) {
+                        src = replaceKey(src, AddeImageURL.KEY_LINEELE, AddeImageURL.KEY_LATLON, selectionProperties.get(AddeImageURL.KEY_LATLON));
+                    }
+                    if (selectionProperties.containsKey(AddeImageURL.KEY_LINEELE)) {
+                        src = removeKey(src, AddeImageURL.KEY_LATLON);
+                        src = replaceKey(src, AddeImageURL.KEY_LINEELE, selectionProperties.get(AddeImageURL.KEY_LINEELE));
+                    }
+                    if (selectionProperties.containsKey(AddeImageURL.KEY_MAG)) {
+                        src = replaceKey(src, AddeImageURL.KEY_MAG, selectionProperties.get(AddeImageURL.KEY_MAG));
+                    }
+                    if (selectionProperties.containsKey(AddeImageURL.KEY_SIZE)) {
+                        src = replaceKey(src, AddeImageURL.KEY_SIZE, selectionProperties.get(AddeImageURL.KEY_SIZE));
+                    }
+                    logger.trace("src after={}", src);
+                    descriptor.setSource(src);
+                }
                 descriptorsToSave.add(descriptor);
             }
 //          descriptorsToSave.addAll(descriptors);


### PR DESCRIPTION
Hey Jon.. I've been poking around occasionally at this problem with re-saving ADDE-image-containing bundles, and I think I've finally come up with a decent looking fix for it.  When you get a chance can you take a look and let me know what you think?  The 2 changes are:

(1)  If the DataCategory from the DataChoice is null, then just set it to DataCategory.CATEGORY_IMAGE.  This avoids an NPE in Hashtable and as far as I can tell only matters for the little tab label that pops up as you are selecting which data to save.

(2)  Only mess with the ADDE URL parameters if we are actually dealing with an ADDE URL (as opposed to local file).  The problem was that when re-saving bundles, we are working with local area files instead of ADDE URLs, and "replaceKey" was adding ADDE parameters on to the end of the filepaths, leading to an invalid URL that would cause "writeTo" to fail later on.

I've mostly tested with local ADDE sources and zipped bundles, but just tried remote/zipped and remote/unzipped and had good luck with those combos also.  I can't even get a local/unzipped bundle to load in the first place, but have the same problem in 1.2- so either I'm doing something dumb there or it's a different issue.

Thanks!
Mike
