### PR TITLE
Get bundles working for Suomi NPP

### DIFF
--- a/edu/wisc/ssec/mcidasv/data/HydraDataSource.java
+++ b/edu/wisc/ssec/mcidasv/data/HydraDataSource.java
@@ -48,7 +48,7 @@ import visad.VisADException;
 public class HydraDataSource extends DataSourceImpl  {
 
     /** List of sources files */
-    protected final List sources = new ArrayList();
+    protected List sources = new ArrayList();
 
     public static String request;
 

--- a/edu/wisc/ssec/mcidasv/data/hydra/GranuleAggregation.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/GranuleAggregation.java
@@ -211,7 +211,6 @@ public class GranuleAggregation implements MultiDimensionReader {
 			   
 			   boolean foundProduct = false;
 			   for (String s : products) {
-				   logger.debug("Seeing if variable is found in product list: " + s);
 				   if (s.contains(var.getShortName())) {
 					   logger.debug("Valid product: " + var.getShortName());
 					   foundProduct = true;


### PR DESCRIPTION
NOTES: a little tricky, needed to persist sets of filenames for granule aggregation, and the adapter index since each datasource has 1-N adapters.  While I was in there, fixed deprecation warnings for Group.getName() that started with most recent Java NetCDF library update.
