### PR TITLE
First stab at fixing a couple Jython Shell issues:

### DIFF
--- a/ucar/unidata/idv/ui/JythonShell.java
+++ b/ucar/unidata/idv/ui/JythonShell.java
@@ -419,7 +419,6 @@ public class JythonShell extends InteractiveShell {
                     // I use 8192 as a threshold because this is apparently the max
                     // that the PythonInterpreter will send to it's OutputStream at a 
                     // single time...not sure how to choose this threshold more intelligently.
-                    // TODO: think of smart way to inform user that their output is being truncated.
                     print(output);
                     output(output.replace("<", "&lt;")
                                  .replace(">", "&gt;")
@@ -638,23 +637,16 @@ public class JythonShell extends InteractiveShell {
                 }
             }
             PythonInterpreter interp = getInterpreter();
-            // MJH March2013: commenting out start/endBufferingOutput calls-
-            // we want the shell output to display as soon as it's available!
-            // Is this smart though??? obviously at some point someone
-            // thought it was a good idea to buffer this output!
-            //startBufferingOutput();
+            // MJH March2013: no longer doing a startBufferingOutput here
             interp.exec(sb.toString());
-            //endBufferingOutput();
             
             // write off history to "store" so user doesn't have to save explicitly.
             saveHistory();
             
             jythonLogger.info(sb.toString());
         } catch (PyException pse) {
-            //endBufferingOutput();
             output("<font color=\"red\">" + formatCode(pse.toString()) + "</font><br/>");
         } catch (Exception exc) {
-            //endBufferingOutput();
             output("<font color=\"red\">" + formatCode(exc.toString()) + "</font><br/>");
         }
     }
@@ -666,7 +658,6 @@ public class JythonShell extends InteractiveShell {
      */
     public void printType(Data d) {
         try {
-            //startBufferingOutput();
             MathType t = d.getType();
             visad.jmet.DumpType.dumpMathType(t, outputStream);
             output("<hr>DataType analysis...");
@@ -674,7 +665,6 @@ public class JythonShell extends InteractiveShell {
         } catch (Exception exc) {
             logException("An error occurred printing types", exc);
         }
-        //endBufferingOutput();
     }
 
     /**

--- a/ucar/unidata/ui/InteractiveShell.java
+++ b/ucar/unidata/ui/InteractiveShell.java
@@ -482,7 +482,6 @@ public class InteractiveShell implements HyperlinkListener {
         SwingUtilities.invokeLater(new Runnable() {
             @Override public void run() {
                 editorPane.setText(sb.toString());
-                // no longer doing a "scrollRectToVisible" here, see "doMakeContents"
             }
         });
     }


### PR DESCRIPTION
(1)  Don't print output to the Jython Shell or jython.log if the string exceeds a threshold of 8192 characters (this is the chunk size that the PythonInterpreter splits its output into, though I have no idea if that is consistent across platforms, etc.).  This combats the problem of the Jython Shell "locking up" when a user prints a big data object.  (Note, in this implementation the user isn't warned when the output is truncated…so far I can't think of a nice way to do this since they would be warned for every single 8192 character chunk that is skipped!).

(2)  Don't buffer the text output.  If you have a long script that is doing intensive calculations or downloading remote data, you want to see the output as soon as it's available, not wait until the entire script is done running.   This one seemed to easy… I feel like I'm missing the rationale behind buffering the output in the first place.

Feel free to suggest/commit improvements or let me know if either of these are a fundamentally bad way of doing things!
