### PR TITLE
Look for 'alpha' and 'beta' for the BIG RED WARNING on the McSplash window []

### DIFF
--- a/edu/wisc/ssec/mcidasv/ui/McvSplash.java
+++ b/edu/wisc/ssec/mcidasv/ui/McvSplash.java
@@ -242,12 +242,12 @@ public class McvSplash extends JWindow {
 		if (version == null) return null;
 		
 		try {
-			int p = version.indexOf('b');
+			int p = version.indexOf("beta");
 			if (p > 0) {
 				hilited += "<br><font color=red>THIS IS BETA SOFTWARE</font>";
 			}
 			else {
-				p = version.indexOf('a');
+				p = version.indexOf("alpha");
 				if (p > 0) {
 					hilited += "<br><font color=red>THIS IS ALPHA SOFTWARE</font>";
 				}


### PR DESCRIPTION
Previously, this just checked for the single characters 'a' and 'b'; however, this caused an issue when using the version.properties.mcidasv.version.release field for an alternate label.  Note this will mean you _must_ use "alpha" or "beta" in the future...
