### PR TITLE
provide access to discreet QF value meanings [978] 

### DIFF
--- a/edu/wisc/ssec/mcidasv/data/QualityFlag.java
+++ b/edu/wisc/ssec/mcidasv/data/QualityFlag.java
@@ -30,6 +30,8 @@
 
 package edu.wisc.ssec.mcidasv.data;
 
+import java.util.HashMap;
+
 /**
  * @author tommyj
  * 
@@ -44,6 +46,7 @@ public class QualityFlag {
 	private int numBits = -1;
 	private String name = null;
 	private String packedName = null;
+	private HashMap<String, String> hm = null;
 	
 	/**
 	 * @param bitOffset
@@ -51,10 +54,11 @@ public class QualityFlag {
 	 * @param name
 	 */
 	
-	public QualityFlag(int bitOffset, int numBits, String name) {
+	public QualityFlag(int bitOffset, int numBits, String name, HashMap<String, String> hm) {
 		this.bitOffset = bitOffset;
 		this.numBits = numBits;
 		this.name = name;
+		this.hm = hm;
 	}
 
 	/**
@@ -111,6 +115,32 @@ public class QualityFlag {
 	 */
 	public void setPackedName(String packedName) {
 		this.packedName = packedName;
+	}
+
+	/**
+	 * @return the hm
+	 */
+	public HashMap<String, String> getHm() {
+		return hm;
+	}
+
+	/**
+	 * @param hm the hm to set
+	 */
+	public void setHm(HashMap<String, String> hm) {
+		this.hm = hm;
+	}
+	
+	/**
+	 * @return the name for a discreet value for this flag
+	 */
+	public String getNameForValue(String valueStr) {
+		if (hm != null) {
+			if (hm.containsKey(valueStr)) {
+				return hm.get(valueStr);
+			}
+		}
+		return null;
 	}
 	
 }

--- a/edu/wisc/ssec/mcidasv/data/hydra/RangeProcessor.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/RangeProcessor.java
@@ -259,6 +259,9 @@ public class RangeProcessor {
 		if (numBits == 2) {
 			mask = (int) 0x00000003;
 		}
+		if (numBits == 3) {
+			mask = (int) 0x00000007;
+		}
 
 		int i = 0;
 		for (int k = 0; k < values.length; k++) {

--- a/edu/wisc/ssec/mcidasv/data/hydra/SuomiNPPDataSource.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/SuomiNPPDataSource.java
@@ -1163,7 +1163,14 @@ public class SuomiNPPDataSource extends HydraDataSource {
       return filename;
     }
     
-    public void setDatasetName(String name) {
+    /**
+	 * @return the qfMap
+	 */
+	public HashMap<String, QualityFlag> getQfMap() {
+		return qfMap;
+	}
+
+	public void setDatasetName(String name) {
       filename = name;
     }
 

--- a/edu/wisc/ssec/mcidasv/data/hydra/SuomiNPPProductProfile.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/SuomiNPPProductProfile.java
@@ -229,6 +229,7 @@ public class SuomiNPPProductProfile {
 						// and store relevant info in a bean
 						if (isQF) {
 							QualityFlag qf = null;
+							HashMap<String, String> hm = new HashMap<String, String>();
 							int bitOffset = -1;
 							int numBits = -1;
 							String description = null;
@@ -282,12 +283,30 @@ public class SuomiNPPProductProfile {
 									description = description.replaceAll("\\s+", "");
 									haveDesc = true;
 								}
-								if (haveOffs && haveSize && haveDesc) {
-									break;
+								if (datumChild.getNodeName().equals("LegendEntry")) {
+									NodeList legendChildren = datumChild.getChildNodes();
+									boolean gotName = false;
+									boolean gotValue = false;
+									String nameStr = null;
+									String valueStr = null;
+									for (int legIdx = 0; legIdx < legendChildren.getLength(); legIdx++) { 
+										Node legendChild = legendChildren.item(legIdx);
+										if (legendChild.getNodeName().equals("Name")) {
+											nameStr = legendChild.getTextContent();
+											gotName = true;
+										}
+										if (legendChild.getNodeName().equals("Value")) {
+											valueStr = legendChild.getTextContent();
+											gotValue = true;
+										}
+									}
+									if (gotName && gotValue) {
+										hm.put(valueStr, nameStr);
+									}
 								}
 							}
 							if (haveOffs && haveSize && haveDesc) {
-								qf = new QualityFlag(bitOffset, numBits, description);
+								qf = new QualityFlag(bitOffset, numBits, description, hm);
 								qfAL.add(qf);
 							}
 						}


### PR DESCRIPTION
Working toward allowing a cursor readout to tell you what each discreet value in a Quality Flag means.  For example:
Cloud Detection and Confidence Pixel
0 : Confidently Clear
1: Probably Clear
2: Probably Cloudy
3: Confidently Cloudy
Pulling all this info from XML Profiles, storing in Quality Flag objects
