### PR TITLE
fix buildWindow sizing problem [1303]

### DIFF
--- a/edu/wisc/ssec/mcidasv/resources/python/background.py
+++ b/edu/wisc/ssec/mcidasv/resources/python/background.py
@@ -579,11 +579,18 @@ class _Display(_JavaProxy):
             self.setSizeBackground(width, height)
             return
         size = Dimension(width, height)
+        #me = self._JavaProxy__javaObject
         navigatedComponent = self._JavaProxy__javaObject.getComponent()
         navigatedComponent.setMinimumSize(size)
         navigatedComponent.setMaximumSize(size)
         navigatedComponent.setPreferredSize(size)
         window = GuiUtils.getWindow(navigatedComponent)
+        #me.getMaster().getDisplay().getComponent().setPreferredSize(size)
+        #me.getMaster().getDisplay().getComponent().setMaximumSize(size)
+        #me.getMaster().getDisplay().getComponent().setMinimumSize(size)
+        #me.getMaster().getDisplay().getDisplayRenderer().getCanvas().setPreferredSize(size)
+        #me.getMaster().getDisplay().getDisplayRenderer().getCanvas().setMaximumSize(size)
+        #me.getMaster().getDisplay().getDisplayRenderer().getCanvas().setMinimumSize(size)
         if not window:
             from javax.swing import JFrame
             window = JFrame()

--- a/ucar/unidata/idv/ViewManager.java
+++ b/ucar/unidata/idv/ViewManager.java
@@ -5645,6 +5645,13 @@ public class ViewManager extends SharableImpl implements ActionListener,
             control.firstFrameDone();
         }
         updateDisplayList();
+        
+        // force a pack() so that the preferred size of this ViewManager's component
+        // is respected after adding the "last active" border.
+        Window window = GuiUtils.getWindow(getComponent());
+        if (window != null) {
+            window.pack();
+        }
     }
 
     /**


### PR DESCRIPTION
Hey Jon, let me know how you feel about this one when you get a chance.. I just force the new ViewManager's containing window to do a pack() after the blue "last active" border is added by setLastActive (which doesn't happen until the FRAME_DONE event is received).

It fixes the issue for me and I think it's a general enough solution to the problem.  Just not sure whether it's a good idea to do a pack() there...
