### PR TITLE
Always make ADDE band info string available in %longname%

### DIFF
--- a/ucar/unidata/idv/control/DisplayControlImpl.java
+++ b/ucar/unidata/idv/control/DisplayControlImpl.java
@@ -3935,7 +3935,9 @@ public abstract class DisplayControlImpl extends DisplayControlBase implements D
             DataSource dataSource = ((DirectDataChoice)dataChoice).getDataSource();
             if (dataSource instanceof AddeImageParameterDataSource) {
                 // return the nice verbose channel info instead of just calibration unit.
-                return dataChoice.getId().toString();
+                if (dataChoice.getId() != null) {
+                    return dataChoice.getId().toString();
+                }
             }
         }
         // end hack


### PR DESCRIPTION
There is currently something of a bug that causes the %longname% macro for ADDE image data sources to get set differently depending on whether there is more than one calibration unit available.  (If only one cal unit, %longname% properly gets set to e.g. "10.7 um IR Surface/Cloud-top Temp".  If there are multiple cal units, then %longname% is just the name of the cal unit, e.g. "Temperature" or "Brightness").

This change makes %longname% consistently get set to the more useful/verbose channel description.  It had to be a bit of a hack so as not to screw up the way things get labeled in the Field Selector, but it works for now.

This is relevant to inquiry [959]
http://dcdbs.ssec.wisc.edu/inquiry-v/?inquiry=959
