### PR TITLE
Fix for CloudSat GEOPROF-2B scale/offset policy change

### DIFF
--- a/edu/wisc/ssec/mcidasv/data/hydra/RangeProcessor.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/RangeProcessor.java
@@ -765,6 +765,10 @@ class CloudSat_2B_GEOPROF_RangeProcessor extends RangeProcessor {
 
 	public CloudSat_2B_GEOPROF_RangeProcessor(MultiDimensionReader reader, HashMap metadata) throws Exception {
 		super(reader, metadata);
+                if (scale == null) { // use implicit default value since E05, E06 has removed the scale/offset from the Radar Refl variable
+                   scale = new float[] {100f};
+                   offset = new float[] {0f};
+                }
 	}
 
 	public float[] processRange(short[] values, HashMap subset) {


### PR DESCRIPTION
If scale/offset not present, use default, scale=100 offset=0
