### PR TITLE
Make sure wavelength readout in multispectral display is always visible [1292]

### DIFF
--- a/edu/wisc/ssec/mcidasv/control/MultiSpectralControl.java
+++ b/edu/wisc/ssec/mcidasv/control/MultiSpectralControl.java
@@ -73,6 +73,9 @@ import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableCellEditor;
 import javax.swing.table.TableCellRenderer;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import visad.DataReference;
 import visad.DataReferenceImpl;
 import visad.FlatField;
@@ -107,7 +110,15 @@ import edu.wisc.ssec.mcidasv.util.Contract;
 
 public class MultiSpectralControl extends HydraControl {
 
-    private String PARAM = "BrightnessTemp";
+	private static final Logger logger = LoggerFactory.getLogger(MultiSpectralControl.class);
+	
+	private String PARAM = "BrightnessTemp";
+	
+	// So MultiSpectralDisplay can consistently update the wavelength label
+	// Note hacky leading spaces - needed because GUI builder does not
+	// accept a horizontal strut component.
+	public static String WAVENUMLABEL = "   Wavelength: ";
+	private JLabel wavelengthLabel = new JLabel();
 
     private static final int DEFAULT_FLAGS = 
         FLAG_COLORTABLE | FLAG_ZPOSITION;
@@ -168,7 +179,7 @@ public class MultiSpectralControl extends HydraControl {
         // map the data choice to display.
         ((McIDASV)getIdv()).getMcvDataManager().setHydraDisplay(choice, display);
 
-        //- intialize the Displayable with data before adding to DisplayControl
+        // initialize the Displayable with data before adding to DisplayControl
         DisplayableData imageDisplay = display.getImageDisplay();
         FlatField image = display.getImageData();
 
@@ -227,6 +238,20 @@ public class MultiSpectralControl extends HydraControl {
 
         return true;
     }
+    
+    /**
+     * Updates the Wavelength label when user manipulates drag line UI
+     * 
+     * @param s full label text, prefix and numeric value
+     * 
+     */
+    
+	public void setWavelengthLabel(String s) {
+		if (s != null) {
+			wavelengthLabel.setText(s);
+		}
+		return;
+	}
 
     @Override public void initDone() {
         try {
@@ -269,6 +294,7 @@ public class MultiSpectralControl extends HydraControl {
      * 
      * @see DisplayControl#setDisplayVisibility(boolean)
      */
+    
     @Override public void setDisplayVisibility(boolean on) {
         super.setDisplayVisibility(on);
         for (Spectrum s : spectra) {
@@ -597,9 +623,10 @@ public class MultiSpectralControl extends HydraControl {
           JLabel nameLabel = new JLabel("Band: ");
           compList.add(nameLabel);
           compList.add(bandBox);
+          compList.add(wavelengthLabel);
         }
 
-        JPanel waveNo = GuiUtils.center(GuiUtils.doLayout(compList, 2, GuiUtils.WT_N, GuiUtils.WT_N));
+        JPanel waveNo = GuiUtils.center(GuiUtils.doLayout(compList, 3, GuiUtils.WT_N, GuiUtils.WT_N));
         return GuiUtils.centerBottom(display.getDisplayComponent(), waveNo);
     }
 

--- a/edu/wisc/ssec/mcidasv/display/hydra/DragLine.java
+++ b/edu/wisc/ssec/mcidasv/display/hydra/DragLine.java
@@ -25,29 +25,30 @@
  * You should have received a copy of the GNU Lesser Public License
  * along with this program.  If not, see http://www.gnu.org/licenses.
  */
+
 package edu.wisc.ssec.mcidasv.display.hydra;
 
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.rmi.RemoteException;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Hashtable;
-import java.util.List;
-import java.util.Map;
 
 import ucar.unidata.util.LogUtil;
+
+import visad.CellImpl;
+import visad.ConstantMap;
+import visad.DataReference;
+import visad.DataReferenceImpl;
+import visad.Display;
+import visad.Gridded1DSet;
+import visad.Gridded2DSet;
+import visad.LocalDisplay;
+import visad.Real;
+import visad.RealTupleType;
+import visad.RealType;
+import visad.VisADException;
+
 import edu.wisc.ssec.mcidasv.data.hydra.GrabLineRendererJ3D;
-import visad.util.Util;
-
-
-import visad.*;
-
 
     public class DragLine extends CellImpl {
+    	
         private final String selectorId = hashCode() + "_selector";
         private final String lineId = hashCode() + "_line";
         private final String controlId;
@@ -59,7 +60,6 @@ import visad.*;
         private DataReference selector;
 
         private RealType domainType;
-        private RealType rangeType;
 
         private RealTupleType tupleType;
 
@@ -68,7 +68,6 @@ import visad.*;
         private float[] YRANGE;
 
         protected float lastSelectedValue;
-
 
         public DragLine(Gridded1DSet domain, RealType domainType, RealType rangeType,
             final float lastSelectedValue, LocalDisplay display, final String controlId, 

--- a/edu/wisc/ssec/mcidasv/display/hydra/MultiSpectralDisplay.java
+++ b/edu/wisc/ssec/mcidasv/display/hydra/MultiSpectralDisplay.java
@@ -74,6 +74,7 @@ import ucar.visad.display.XYDisplay;
 import edu.wisc.ssec.mcidasv.control.HydraCombo;
 import edu.wisc.ssec.mcidasv.control.HydraControl;
 import edu.wisc.ssec.mcidasv.control.LinearCombo;
+import edu.wisc.ssec.mcidasv.control.MultiSpectralControl;
 import edu.wisc.ssec.mcidasv.data.HydraDataSource;
 import edu.wisc.ssec.mcidasv.data.hydra.GrabLineRendererJ3D;
 import edu.wisc.ssec.mcidasv.data.hydra.HydraRGBDisplayable;
@@ -163,7 +164,6 @@ public class MultiSpectralDisplay implements DisplayListener {
                 }
               }
               HashMap subset = select.getSubset();
-//              logger.debug("waveNumber={} subset={}", waveNumber, subset);
               image = data.getImage(waveNumber, subset);
               image = changeRangeType(image, uniqueRangeType);
             }
@@ -432,6 +432,7 @@ public class MultiSpectralDisplay implements DisplayListener {
             return selectors.get(id);
 
         DragLine selector = new DragLine(this, id, color, initialRangeY);
+        selector.setHydraControl(displayControl);
         selector.setSelectedValue(waveNumber);
         selectors.put(id, selector);
         return selector;
@@ -707,6 +708,8 @@ public class MultiSpectralDisplay implements DisplayListener {
         private DataReference selector;
 
         private MultiSpectralDisplay multiSpectralDisplay;
+        
+        private HydraControl hydraControl;
 
         private RealType domainType;
         private RealType rangeType;
@@ -763,7 +766,7 @@ public class MultiSpectralDisplay implements DisplayListener {
             line = new DataReferenceImpl(lineId);
 
             display = multiSpectralDisplay.getDisplay();
-            
+
             display.addReferences(new GrabLineRendererJ3D(domain), new DataReference[] { selector }, new ConstantMap[][] { mappings });
             display.addReference(line, cloneMappedColor(color));
 
@@ -819,7 +822,25 @@ public class MultiSpectralDisplay implements DisplayListener {
 
             selector.setData(new Real(domainType, val));
             lastSelectedValue = val;
+            
+            if (hydraControl instanceof MultiSpectralControl) {
+            	((MultiSpectralControl) hydraControl).setWavelengthLabel
+            	(
+            			MultiSpectralControl.WAVENUMLABEL + val
+            	);
+            }
             multiSpectralDisplay.updateControlSelector(controlId, val);
         }
+
+		/**
+		 * Set the display control so we can call back and update
+		 * wavelength readout in real time.
+		 * 
+		 * @param hydraControl the display control to set
+		 */
+        
+		public void setHydraControl(HydraControl hydraControl) {
+			this.hydraControl = hydraControl;
+		}
     }
 }


### PR DESCRIPTION
Note: previous behavior was technically correct, since cursor readout in VisAD is intended to track and display values only during mouse movement.  By disabling this readout and showing wavelength in a GUI JLabel we can insure it's always present for users.
