### PR TITLE
Use Jython's PosixModule to grab process id for mcservl.

### DIFF
--- a/edu/wisc/ssec/mcidasv/servermanager/EntryStore.java
+++ b/edu/wisc/ssec/mcidasv/servermanager/EntryStore.java
@@ -41,6 +41,8 @@ import org.bushe.swing.event.EventBus;
 import org.bushe.swing.event.annotation.AnnotationProcessor;
 import org.bushe.swing.event.annotation.EventSubscriber;
 
+import org.python.modules.posix.PosixModule;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -278,13 +280,13 @@ public class EntryStore {
     }
 
     protected String[] getAddeCommands() {
-    	String mcvPID = System.getProperty("mcv.pid");
-    	if (mcvPID == null) {
-    		return new String[] { ADDE_MCSERVL, "-v", "-p", localPort };
-    	}
-    	else {
-    		return new String[] { ADDE_MCSERVL, "-v", "-p", localPort, "-i", mcvPID };    		
-    	}
+        String mcvPID = Integer.toString(PosixModule.getpid());
+        if ((mcvPID == null) || ("0".equals(mcvPID))) {
+            return new String[] { ADDE_MCSERVL, "-v", "-p", localPort };
+        }
+        else {
+            return new String[] { ADDE_MCSERVL, "-v", "-p", localPort, "-i", mcvPID };
+        }
     }
 
     /**


### PR DESCRIPTION
Jython relies on jnr-posix to provide a "POSIX emulation layer" on a wide variety of platforms (AIX, FreeBSD, Linux, OS X, OpenBSD, Solaris, and Windows)…all without having to fuss around with JNI and compiling native code.

I know that on Unix-like systems we're currently passing runMcV's process id to mcservl, but I looked through mcservl's source code and unless I'm mistaken we can use the JVM's process id to achieve the same results (and it would mean that things work the same on Unix-likes and Windows).
