### PR TITLE
Make sure empty/anon dimension names always get initialized [1641]

### DIFF
--- a/edu/wisc/ssec/mcidasv/data/hydra/GranuleAggregation.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/GranuleAggregation.java
@@ -452,7 +452,10 @@ public class GranuleAggregation implements MultiDimensionReader {
 				   }
 				   String dimName = dim.getShortName();
 				   logger.debug("GranuleAggregation init, variable: " + varName + ", dimension name: " + dimName + ", length: " + dim.getLength());
-				   if (dimName == null) dimName = "dim" + cnt;
+				   if (dimName == null)  dimName = "dim" + cnt;
+				   if (dimName.isEmpty()) {
+					   dimName = "dim" + cnt;
+				   }
 				   dimNames[cnt] = dimName;
 				   dimLengths[cnt] = dim.getLength();
 				   cnt++;


### PR DESCRIPTION
Gets CrIS working again, which apparently is broken at the moment :-(
