### PR TITLE
Add qfMap to IDV's "translations" hashmap on initialization.  This makes...

### DIFF
--- a/edu/wisc/ssec/mcidasv/data/hydra/SuomiNPPDataSource.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/SuomiNPPDataSource.java
@@ -1461,7 +1461,8 @@ public class SuomiNPPDataSource extends HydraDataSource {
         	// check if we've already added map for this QF
         	if (!translations.containsKey(qfKeySubstr)) {
 	        	Map<String, String> hm = qfMap.get(qfKey).getHm();
-	        	Map<Integer, String> newMap = new HashMap();
+	        	Map<Integer, String> newMap = 
+	        			new HashMap<Integer, String>(hm.size());
 	        	for (String dataValueKey : hm.keySet()) {
 	        		// convert Map<String, String> to Map<Integer, String>
 	        		Integer intKey = Integer.parseInt(dataValueKey);

--- a/edu/wisc/ssec/mcidasv/resources/controls.xml
+++ b/edu/wisc/ssec/mcidasv/resources/controls.xml
@@ -98,14 +98,6 @@
      displaycategory="Radar Displays"
      properties="windowVisible=true;"/>
   <control
-     id="suominppqf"
-     categories="VIIRS*"
-     class="edu.wisc.ssec.mcidasv.control.SuomiNPPQfControl"
-     description="Suomi NPP Quality Flag Display"
-     label="Suomi NPP Quality Flag Display"
-     displaycategory="Imagery"
-     properties="windowVisible=true;"/>
-  <control
      id="rgbcomposite"
      categories="RGBC"
      class="edu.wisc.ssec.mcidasv.control.RGBCompositeControl"


### PR DESCRIPTION
Tommy, maybe we can look at this together tomorrow morning since it's a change to SuomiNPPDataSource...  by adding qfMap to IDV's "translations" hash table, the data probe will show the QF strings in a plain "Image Display" instead of having to choose the separate "Suomi NPP Quality Flag Display" (very easy to forget to do as a user).  This should fix [Inquiry 1466.](http://dcdbs.ssec.wisc.edu/inquiry-v/?inquiry=1466)   

[1466]
