### PR TITLE
Bring in Logbridge module.

### DIFF
--- a/edu/wisc/ssec/mcidasv/resources/python/logbridge/__init__.py
+++ b/edu/wisc/ssec/mcidasv/resources/python/logbridge/__init__.py
@@ -1,0 +1,56 @@
+import logging
+from org.slf4j import Logger, LoggerFactory
+
+
+__all__ = ["SLF4JHandler"]
+
+
+class SLF4JHandler(logging.Handler):
+
+    def __init__(self, logger=None):
+        logging.Handler.__init__(self)
+        if logger is None:
+            logger = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)
+        self.logger = logger
+
+    # No need for lock management of the interaction with SLF4J
+    # itself, given that SLF4J ensures appropriate serialization
+
+    def createLock(self):
+        pass
+
+    def acquire(self):
+        pass
+
+    def release(self):
+        pass
+
+    # Nor a need to flush - we are working with a logging system!
+
+    def flush(self):
+        pass
+
+    # Avoid formatting messages if possible; doing this switch style lookup
+    # is probably the least expensive way to do this
+    def emit(self, record):
+        try:
+            level = record.levelno
+            if self.logger.isErrorEnabled() and level >= logging.ERROR:
+                msg = self.format(record)
+                self.logger.error(msg)
+            elif self.logger.isWarnEnabled() and level >= logging.WARNING:
+                msg = self.format(record)
+                self.logger.warn(msg)
+            elif self.logger.isInfoEnabled() and level >= logging.INFO:
+                msg = self.format(record)
+                self.logger.info(msg)
+            elif self.logger.isDebugEnabled() and level >= logging.DEBUG:
+                msg = self.format(record)
+                self.logger.debug(msg)
+            elif self.logger.isTraceEnabled() and level >= logging.NOTSET:
+                msg = self.format(record)
+                self.logger.trace(msg)
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except:
+            self.handleError(record)


### PR DESCRIPTION
[Logbridge](https://github.com/jythontools/logbridge) is a bridge between Python's [logging](https://docs.python.org/2/library/logging.html) API and [Simple Logging Facade for Java (SLF4J)](http://www.slf4j.org/).

The example already works fairly well in McV straight from the Jython Shell (just need to remove the “invoke0” bit):

```
[java] 09:02:47.202 [Thread-123] DEBUG ROOT - invoke0: debug message
[java] 09:02:47.203 [Thread-123] INFO ROOT - invoke0: info message
[java] 09:02:47.204 [Thread-123] WARN ROOT - invoke0: warn message
[java] 09:02:47.205 [Thread-123] ERROR ROOT - invoke0: error message
[java] 09:02:47.206 [Thread-123] ERROR ROOT - invoke0: critical message
```
