### PR TITLE
think i've worked out the problem

### DIFF
--- a/edu/wisc/ssec/mcidasv/data/hydra/SuomiNPPDataSource.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/SuomiNPPDataSource.java
@@ -322,6 +322,8 @@ public class SuomiNPPDataSource extends HydraDataSource {
     			String keyStr = (String) keyIterator.next();
         		List fileNames = (List) filenameMap.get(keyStr);
         		granuleCount = fileNames.size();
+				setProperty("granuleCount", granuleCount);
+				logger.trace("properties='{}'", getProperties());
     			for (int fileCount = 0; fileCount < granuleCount; fileCount++) {
     				// need to open the main NetCDF file to determine the geolocation product
     				NetcdfFile ncfile = null;
@@ -1192,8 +1194,12 @@ public class SuomiNPPDataSource extends HydraDataSource {
     			logger.error("Exception: ", e);
     		}
     	}
-
-    	setProperties(properties);
+		logger.info("local properties='{}'", properties);
+		logger.info("getProperties='{}'", getProperties());
+		Hashtable temp = getProperties();
+		temp.putAll(properties);
+		logger.info("temp='{}'", temp);
+		setProperties(temp);
     }
 
     public void initAfterUnpersistence() {
@@ -1282,6 +1288,7 @@ public class SuomiNPPDataSource extends HydraDataSource {
     			DataChoice choice = null;
 				try {
 					choice = doMakeDataChoice(k, adapter);
+					choice.setObjectProperty("granuleCount", getProperty("granuleCount", -2));
 	    			msdMap.put(choice.getName(), adapter);
 	    			addDataChoice(choice);
 				} catch (Exception e) {
@@ -1297,6 +1304,7 @@ public class SuomiNPPDataSource extends HydraDataSource {
     			DataChoice choice = null;
     			try {
     				choice = doMakeDataChoice(idx, adapters[idx].getArrayName());
+					choice.setObjectProperty("granuleCount", getProperty("granuleCount", -2));
     			} 
     			catch (Exception e) {
     				e.printStackTrace();

--- a/ucar/unidata/idv/control/DisplayControlImpl.java
+++ b/ucar/unidata/idv/control/DisplayControlImpl.java
@@ -29,6 +29,7 @@
 package ucar.unidata.idv.control;
 
 
+import edu.wisc.ssec.mcidasv.data.hydra.SuomiNPPDataSource;
 import edu.wisc.ssec.mcidasv.ui.ColorSwatchComponent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -4246,7 +4247,16 @@ public abstract class DisplayControlImpl extends DisplayControlBase implements D
         } else {
             values.add(resolutionReadout);
         }
-
+        if (getDataChoice() != null) {
+            Object granuleCount = getDataChoice().getProperty("granuleCount");
+            if (granuleCount == null) {
+                granuleCount = "";
+            }
+            patterns.add("%granulecount%");
+            values.add(granuleCount.toString());
+        }
+        logger.trace("patterns='{}'", patterns);
+        logger.trace("values='{}'", values);
     }
 
 
@@ -6390,6 +6400,14 @@ public abstract class DisplayControlImpl extends DisplayControlBase implements D
         if (canDoProgressiveResolution()) {
             names.addAll(Misc.newList(MACRO_RESOLUTION));
             labels.addAll(Misc.newList("Resolution"));
+        }
+        if (getDataChoice() != null) {
+            Object granuleCount = getDataChoice().getProperty("granuleCount");
+            if (granuleCount == null) {
+                granuleCount = "";
+            }
+            names.add("%granulecount%");
+            labels.add("Granule Count");
         }
     }
 


### PR DESCRIPTION
The problem _appears_ to have resulted from the last few lines of `SuomiNPPSuomiNPPDataSource.setup()`: the `setProperties(properties)` call was overwriting the data source properties that had been set earlier in the method. I opted to simply merge `properties` with the existing map returned by `getProperties()`. My limited tests resulted in `properties` always being empty.

I made things a little more flexible by (ab)using the data choice properties in `doMakeDataChoices`. This allows the `DisplayControlImpl` code in `addLabelMacros` and `getMacroNames` to check for the presence of the `granulecount` property without having to use instanceof checks and whatnot.

Things seem to work, but I haven't tested the changes thoroughly, and the code is pretty messy (I'm getting tired)…so merging this pull request is probably not a great idea. I mostly wanted to get the code online and viewable in a side-by-side diff.

(there are two buttons to the right of the "Showing 2 changed files ..." line below, "Unified" and "Split". Pick "Split" to get the side-by-side diffs)
