### PR TITLE
Fix for problem with AIRS data. [2027]

### DIFF
--- a/edu/wisc/ssec/mcidasv/data/hydra/MultiSpectralDataSource.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/MultiSpectralDataSource.java
@@ -245,7 +245,7 @@ public class MultiSpectralDataSource extends HydraDataSource {
         		subset.put(SpectrumAdapter.channelIndex_name, new double[] {793,793,1});
         		defaultSubset = subset;
 
-        		MultiSpectralData multiSpectData = new MultiSpectralData(swathAdapter, spectrumAdapter);
+        		multiSpectData = new MultiSpectralData(swathAdapter, spectrumAdapter);
         		// Need to change paramater and range for Radiance, default is Brightness Temp, so
         		// do nothing for 2nd time through loop
         		if (i == 0) {


### PR DESCRIPTION
The locally defined (in `setup()`) `multiSpectData` was shadowing the _instance_ version of `multiSpectData`. This led to multiSpectData being `null` when `getDataProjection()` attempts to call
`multiSpectData.getLonLatBoundingBox(...)`.