### PR TITLE
move front clipping plane away from eye: depth buffer resolution is s…

### DIFF
--- a/edu/wisc/ssec/mcidasv/resources/mcidasv.properties
+++ b/edu/wisc/ssec/mcidasv/resources/mcidasv.properties
@@ -30,17 +30,17 @@ visad.sampledset.cachesizethreshold=10000
 ########################################################################
 ## <unidata's "clip distance" props>
 ########################################################################
-idv.clipdistance.globe.front=-1000
+idv.clipdistance.globe.front=-200
 idv.clipdistance.globe.back=1000
 
-idv.clipdistance.map.front=-1000
+idv.clipdistance.map.front=-100
 idv.clipdistance.map.back=1000
 
-mac.idv.clipdistance.globe.front=-100
-mac.idv.clipdistance.globe.back=100
+mac.idv.clipdistance.globe.front=-200
+mac.idv.clipdistance.globe.back=1000
 
-mac.idv.clipdistance.map.front=-20
-mac.idv.clipdistance.map.back=20
+mac.idv.clipdistance.map.front=-100
+mac.idv.clipdistance.map.back=1000
 ## </unidata's "clip distance" props>
 ########################################################################
 


### PR DESCRIPTION
…tacked

toward the front while back plane position has less impact on overall
depth precision. These new setting help with overlayed image interference
patterns in the MapDisplay by wasting less precision. Note: these may
have to be modified across different display depth resolutions: 16,24,32bit.