### PR TITLE
Hydra method signature refactor

### DIFF
--- a/edu/wisc/ssec/mcidasv/control/HydraCombo.java
+++ b/edu/wisc/ssec/mcidasv/control/HydraCombo.java
@@ -151,7 +151,7 @@ public class HydraCombo extends HydraControl {
     
     @Override public MapProjection getDataProjection() {
         MapProjection mp = null;
-        HashMap subset = null;
+        Map<String, double[]> subset = null;
         Hashtable table = dataChoice.getProperties();
         MultiDimensionSubset dataSel =
            (MultiDimensionSubset) table.get(MultiDimensionSubset.key);

--- a/edu/wisc/ssec/mcidasv/control/LinearCombo.java
+++ b/edu/wisc/ssec/mcidasv/control/LinearCombo.java
@@ -200,7 +200,7 @@ public class LinearCombo extends HydraControl implements ConsoleCallback {
 
     @Override public MapProjection getDataProjection() {
         MapProjection mp = null;
-        HashMap subset = null;
+        Map<String, double[]> subset = null;
         Hashtable table = dataChoice.getProperties();
         MultiDimensionSubset dataSel =
            (MultiDimensionSubset)table.get(MultiDimensionSubset.key);

--- a/edu/wisc/ssec/mcidasv/data/PreviewSelection.java
+++ b/edu/wisc/ssec/mcidasv/data/PreviewSelection.java
@@ -36,6 +36,7 @@ import java.rmi.RemoteException;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Hashtable;
+import java.util.Map;
 
 import javax.swing.JComponent;
 import javax.swing.JOptionPane;
@@ -301,13 +302,13 @@ public class PreviewSelection extends DataSelectionComponent {
 
              if (hasSubset) {
                MultiDimensionSubset select = hydraContext.getMultiDimensionSubset();
-               HashMap map = select.getSubset();
+                 Map<String, double[]> map = select.getSubset();
 
-               double[] coords0 = (double[]) map.get("Track");
+               double[] coords0 = map.get("Track");
                coords0[0] = y_coords[0];
                coords0[1] = y_coords[1];
                coords0[2] = 1;
-               double[] coords1 = (double[]) map.get("XTrack");
+               double[] coords1 = map.get("XTrack");
                coords1[0] = x_coords[0];
                coords1[1] = x_coords[1];
                coords1[2] = 1;

--- a/edu/wisc/ssec/mcidasv/data/hydra/AIRS_L1B_Spectrum.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/AIRS_L1B_Spectrum.java
@@ -31,7 +31,7 @@ package edu.wisc.ssec.mcidasv.data.hydra;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.HashMap;
+import java.util.Map;
 import java.util.StringTokenizer;
 
 public class AIRS_L1B_Spectrum extends SpectrumAdapter {
@@ -40,7 +40,7 @@ public class AIRS_L1B_Spectrum extends SpectrumAdapter {
   float[] srf_centroid_freq;
   int[] radiance_quality;
 
-  public AIRS_L1B_Spectrum(MultiDimensionReader reader, HashMap metadata) {
+  public AIRS_L1B_Spectrum(MultiDimensionReader reader, Map<String, Object> metadata) {
     super(reader, metadata);
   }
 

--- a/edu/wisc/ssec/mcidasv/data/hydra/AggregationRangeProcessor.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/AggregationRangeProcessor.java
@@ -30,18 +30,20 @@ package edu.wisc.ssec.mcidasv.data.hydra;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class AggregationRangeProcessor extends RangeProcessor {
 
-	ArrayList<RangeProcessor> rangeProcessors = new ArrayList<RangeProcessor>();
+	List<RangeProcessor> rangeProcessors = new ArrayList<>();
 
 	int rngIdx = 0;
 
 	public AggregationRangeProcessor(GranuleAggregation aggrReader,
-			HashMap metadata) throws Exception {
+			Map<String, Object> metadata) throws Exception {
 		super();
 
-		ArrayList readers = aggrReader.getReaders();
+		List readers = aggrReader.getReaders();
 
 		int num = 0;
 
@@ -75,19 +77,19 @@ public class AggregationRangeProcessor extends RangeProcessor {
 		rangeProcessors.get(rngIdx).setMultiScaleIndex(idx);
 	}
 
-	public synchronized float[] processRange(byte[] values, HashMap subset) {
+	public synchronized float[] processRange(byte[] values, Map<String, double[]> subset) {
 		return rangeProcessors.get(rngIdx).processRange(values, subset);
 	}
 
-	public synchronized float[] processRange(short[] values, HashMap subset) {
+	public synchronized float[] processRange(short[] values, Map<String, double[]> subset) {
 		return rangeProcessors.get(rngIdx).processRange(values, subset);
 	}
 
-	public synchronized float[] processRange(float[] values, HashMap subset) {
+	public synchronized float[] processRange(float[] values, Map<String, double[]> subset) {
 		return rangeProcessors.get(rngIdx).processRange(values, subset);
 	}
 
-	public synchronized double[] processRange(double[] values, HashMap subset) {
+	public synchronized double[] processRange(double[] values, Map<String, double[]> subset) {
 		return rangeProcessors.get(rngIdx).processRange(values, subset);
 	}
 }

--- a/edu/wisc/ssec/mcidasv/data/hydra/AggregationRangeProcessor.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/AggregationRangeProcessor.java
@@ -43,13 +43,13 @@ public class AggregationRangeProcessor extends RangeProcessor {
 			Map<String, Object> metadata) throws Exception {
 		super();
 
-		List readers = aggrReader.getReaders();
+		List<NetCDFFile> readers = aggrReader.getReaders();
 
 		int num = 0;
 
 		for (int rdrIdx = 0; rdrIdx < readers.size(); rdrIdx++) {
 			RangeProcessor rngProcessor = RangeProcessor.createRangeProcessor(
-					(MultiDimensionReader) readers.get(rdrIdx), metadata);
+					readers.get(rdrIdx), metadata);
 
 			if (rngProcessor.hasMultiDimensionScale()) {
 				num++;

--- a/edu/wisc/ssec/mcidasv/data/hydra/ArrayAdapter.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/ArrayAdapter.java
@@ -29,6 +29,7 @@
 package edu.wisc.ssec.mcidasv.data.hydra;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import visad.FunctionType;
 import visad.GriddedSet;
@@ -51,7 +52,7 @@ public class ArrayAdapter extends MultiDimensionAdapter {
    public ArrayAdapter() {
    }
 
-   public ArrayAdapter(MultiDimensionReader reader, HashMap metadata) {
+   public ArrayAdapter(MultiDimensionReader reader, Map<String, Object> metadata) {
      super(reader, metadata);
      init();
    }
@@ -91,7 +92,7 @@ public class ArrayAdapter extends MultiDimensionAdapter {
      return ftype;
    }
 
-   public GriddedSet makeDomain(Object subset) throws Exception {
+   public GriddedSet makeDomain(Map<String, double[]> subset) throws Exception {
      if (subset == null) {
         subset = getDefaultSubset();
      }
@@ -129,8 +130,8 @@ public class ArrayAdapter extends MultiDimensionAdapter {
      return new_domain;
    }
 
-   public HashMap getDefaultSubset() {
-     HashMap map = getEmptySubset();
+   public Map<String, double[]> getDefaultSubset() {
+     Map<String, double[]> map = getEmptySubset();
      for (int i=0; i<array_rank; i++) {
        double[] coords = (double[]) map.get(dimNameMap.get(array_dim_names[i]));
        coords[0] = 0;
@@ -140,8 +141,8 @@ public class ArrayAdapter extends MultiDimensionAdapter {
      return map;
    }
 
-   public HashMap getEmptySubset() {
-     HashMap<String, double[]> subset = new HashMap<String, double[]>();
+   public Map<String, double[]> getEmptySubset() {
+     Map<String, double[]> subset = new HashMap<>();
      for (int i=0; i<array_rank; i++) {
        subset.put(dimNameMap.get(array_dim_names[i]), new double[3]);
      }

--- a/edu/wisc/ssec/mcidasv/data/hydra/Calipso2D.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/Calipso2D.java
@@ -46,6 +46,7 @@ import java.rmi.RemoteException;
 
 import java.util.Hashtable;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.StringTokenizer;
 
 import java.io.BufferedReader;
@@ -62,13 +63,13 @@ public class Calipso2D extends ProfileAlongTrack {
       public Calipso2D() {
       }
 
-      public Calipso2D(MultiDimensionReader reader, HashMap metadata, boolean isVertTypeAlt) {
+      public Calipso2D(MultiDimensionReader reader, Map<String, Object> metadata, boolean isVertTypeAlt) {
         super(reader, metadata, isVertTypeAlt);
       }
 
-      public Calipso2D(MultiDimensionReader reader, HashMap metadata) {
+      public Calipso2D(MultiDimensionReader reader, Map<String, Object> metadata) {
         super(reader, metadata);
-        HashMap table = ProfileAlongTrack.getEmptyMetadataTable();
+        Map<String, Object> table = ProfileAlongTrack.getEmptyMetadataTable();
         table.put(ProfileAlongTrack.array_name, "Surface_Elevation");
       }
 
@@ -143,7 +144,7 @@ public class Calipso2D extends ProfileAlongTrack {
         return timeType;
       }
 
-      public FlatField getData(Object subset) throws Exception {
+      public FlatField getData(Map<String, double[]> subset) throws Exception {
         FlatField field = super.getData(subset);
         return field;
       }

--- a/edu/wisc/ssec/mcidasv/data/hydra/CloudSat2D.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/CloudSat2D.java
@@ -43,6 +43,7 @@ import java.rmi.RemoteException;
 
 import java.util.Hashtable;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.StringTokenizer;
 
 import java.io.BufferedReader;
@@ -57,7 +58,7 @@ public class CloudSat2D extends ProfileAlongTrack {
       public CloudSat2D() {
       }
 
-      public CloudSat2D(MultiDimensionReader reader, HashMap metadata) {
+      public CloudSat2D(MultiDimensionReader reader, Map<String, Object> metadata) {
         super(reader, metadata);
       }
 
@@ -119,16 +120,16 @@ public class CloudSat2D extends ProfileAlongTrack {
         return vals;
       }
 
-      public HashMap getDefaultSubset() {
-        HashMap subset = ProfileAlongTrack.getEmptySubset();
+      public Map<String, double[]> getDefaultSubset() {
+        Map<String, double[]> subset = ProfileAlongTrack.getEmptySubset();
 
-        double[] coords = (double[])subset.get("TrackDim");
+        double[] coords = subset.get("TrackDim");
         coords[0] = 1000.0;
         coords[1] = (TrackLen - 1000.0) - 1;
         coords[2] = 5.0;
         subset.put("TrackDim", coords);
 
-        coords = (double[])subset.get("VertDim");
+        coords = subset.get("VertDim");
         coords[0] = 10.0;
         coords[1] = (VertLen) - 1;
         coords[2] = 2.0;

--- a/edu/wisc/ssec/mcidasv/data/hydra/CloudSat_2B_GEOPROF_RangeProcessor.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/CloudSat_2B_GEOPROF_RangeProcessor.java
@@ -43,7 +43,7 @@ public class CloudSat_2B_GEOPROF_RangeProcessor extends RangeProcessor {
 		}
 	}
 
-	public float[] processRange(short[] values, Map subset) {
+	public float[] processRange(short[] values, Map<String, double[]> subset) {
 		float[] new_values = new float[values.length];
 		for (int k = 0; k < values.length; k++) {
 			float val = (float) values[k];

--- a/edu/wisc/ssec/mcidasv/data/hydra/CloudSat_2B_GEOPROF_RangeProcessor.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/CloudSat_2B_GEOPROF_RangeProcessor.java
@@ -28,12 +28,12 @@
 
 package edu.wisc.ssec.mcidasv.data.hydra;
 
-import java.util.HashMap;
+import java.util.Map;
 
 public class CloudSat_2B_GEOPROF_RangeProcessor extends RangeProcessor {
 
 	public CloudSat_2B_GEOPROF_RangeProcessor(MultiDimensionReader reader,
-			HashMap metadata) throws Exception {
+			Map<String, Object> metadata) throws Exception {
 		super(reader, metadata);
 		if (scale == null) { // use implicit default value since E05, E06 has
 								// removed the scale/offset from the Radar Refl
@@ -43,7 +43,7 @@ public class CloudSat_2B_GEOPROF_RangeProcessor extends RangeProcessor {
 		}
 	}
 
-	public float[] processRange(short[] values, HashMap subset) {
+	public float[] processRange(short[] values, Map subset) {
 		float[] new_values = new float[values.length];
 		for (int k = 0; k < values.length; k++) {
 			float val = (float) values[k];

--- a/edu/wisc/ssec/mcidasv/data/hydra/CrIS_RangeProcessor.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/CrIS_RangeProcessor.java
@@ -28,7 +28,7 @@
 
 package edu.wisc.ssec.mcidasv.data.hydra;
 
-import java.util.HashMap;
+import java.util.Map;
 
 public class CrIS_RangeProcessor extends RangeProcessor {
 
@@ -36,7 +36,7 @@ public class CrIS_RangeProcessor extends RangeProcessor {
 		super();
 	}
 
-	public float[] processRange(float[] values, HashMap subset) {
+	public float[] processRange(float[] values, Map<String, double[]> subset) {
 
 		double[] track_coords = (double[]) subset.get(SwathAdapter.track_name);
 		int numLines = ((int) (track_coords[1] - track_coords[0]) + 1);

--- a/edu/wisc/ssec/mcidasv/data/hydra/CrIS_SDR_Spectrum.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/CrIS_SDR_Spectrum.java
@@ -29,6 +29,7 @@
 package edu.wisc.ssec.mcidasv.data.hydra;
                                                                                                                                                            
 import java.util.HashMap;
+import java.util.Map;
 
 public class CrIS_SDR_Spectrum extends SpectrumAdapter {
 
@@ -42,7 +43,7 @@ public class CrIS_SDR_Spectrum extends SpectrumAdapter {
   // Pick a wavelength for the preview where there is likely to be a decent visual slice
   private static final float DEFAULT_PREVIEW_WAVENUMBER = 902.25f;
 
-  public CrIS_SDR_Spectrum(MultiDimensionReader reader, HashMap metadata) {
+  public CrIS_SDR_Spectrum(MultiDimensionReader reader, Map<String, Object> metadata) {
     super(reader, metadata);
   }
   

--- a/edu/wisc/ssec/mcidasv/data/hydra/CrIS_SDR_SwathAdapter.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/CrIS_SDR_SwathAdapter.java
@@ -29,6 +29,7 @@
 package edu.wisc.ssec.mcidasv.data.hydra;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import visad.FlatField;
 import visad.Set;
@@ -38,7 +39,7 @@ public class CrIS_SDR_SwathAdapter extends SwathAdapter {
    public CrIS_SDR_SwathAdapter() {
    }
 
-   public CrIS_SDR_SwathAdapter(MultiDimensionReader reader, HashMap metadata) {
+   public CrIS_SDR_SwathAdapter(MultiDimensionReader reader, Map<String, Object> metadata) {
      super(reader, metadata);
    }
 
@@ -49,12 +50,13 @@ public class CrIS_SDR_SwathAdapter extends SwathAdapter {
      setXTrackLength(len *= 9);
    }
 
-   public FlatField getData(Object subset) throws Exception {
+   public FlatField getData(Map<String, double[]> subset) throws Exception {
 
      Set domainSet = makeDomain(subset);
 
-     HashMap new_subset = (HashMap) ((HashMap)subset).clone();
-     new_subset.putAll((HashMap)subset);
+//     HashMap new_subset = (HashMap) ((HashMap)subset).clone();
+//     new_subset.putAll((HashMap)subset);
+     Map<String, double[]> new_subset = new HashMap<>(subset);
 
      double[] coords = (double[]) new_subset.get(SwathAdapter.track_name);
      double[] new_coords = new double[] {0.0, coords[1], 1.0};

--- a/edu/wisc/ssec/mcidasv/data/hydra/IASI_L1C_Spectrum.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/IASI_L1C_Spectrum.java
@@ -34,6 +34,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.Map;
 import java.util.StringTokenizer;
 import visad.Set;
 import visad.FlatField;
@@ -48,9 +49,9 @@ public class IASI_L1C_Spectrum extends SpectrumAdapter {
   //-public static int[][] ifov_order2 = new int[][] {new int[] {0,1}, new int[] {1,1}, new int[] {1,0}, new int[] {0,0}};
   public static int[][] ifov_order2 = new int[][] {new int[] {1,1}, new int[] {0,-1}, new int[] {0,0}, new int[] {-1,0}};
 
-  public HashMap new_subset = new HashMap();
+  public Map<String, double[]> new_subset = new HashMap<>();
 
-  public IASI_L1C_Spectrum(MultiDimensionReader reader, HashMap metadata) {
+  public IASI_L1C_Spectrum(MultiDimensionReader reader, Map<String, Object> metadata) {
     super(reader, metadata);
   }
 
@@ -68,11 +69,11 @@ public class IASI_L1C_Spectrum extends SpectrumAdapter {
   }
 
    
-  public FlatField getData(Object subset) throws Exception {
-     new_subset.putAll((HashMap) subset);
+  public FlatField getData(Map<String, double[]> subset) throws Exception {
+     new_subset.putAll(subset);
 
-     double[] xx = (double[]) ((HashMap)subset).get(SpectrumAdapter.x_dim_name);
-     double[] yy = (double[]) ((HashMap)subset).get(SpectrumAdapter.y_dim_name);
+     double[] xx = subset.get(SpectrumAdapter.x_dim_name);
+     double[] yy = subset.get(SpectrumAdapter.y_dim_name);
      double[] new_xx = new double[3];
      double[] new_yy = new double[3];
 
@@ -103,7 +104,7 @@ public class IASI_L1C_Spectrum extends SpectrumAdapter {
      return super.getData(new_subset);
    }
 
-  public float[] processRange(short[] range, Object subset) {
+  public float[] processRange(short[] range, Map<String, double[]> subset) {
     return IASI_L1C_Utility.getDecodedIASISpectra(range, null);
   }
 

--- a/edu/wisc/ssec/mcidasv/data/hydra/IASI_L1C_SwathAdapter.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/IASI_L1C_SwathAdapter.java
@@ -42,6 +42,7 @@ import visad.VisADException;
 import java.rmi.RemoteException;
 import java.util.Hashtable;
 import java.util.HashMap;
+import java.util.Map;
 
 
 public class IASI_L1C_SwathAdapter extends SwathAdapter {
@@ -49,7 +50,7 @@ public class IASI_L1C_SwathAdapter extends SwathAdapter {
    public IASI_L1C_SwathAdapter() {
    }
 
-   public IASI_L1C_SwathAdapter(MultiDimensionReader reader, HashMap metadata) {
+   public IASI_L1C_SwathAdapter(MultiDimensionReader reader, Map<String, Object> metadata) {
      super(reader, metadata);
    }
 
@@ -60,13 +61,12 @@ public class IASI_L1C_SwathAdapter extends SwathAdapter {
      setXTrackLength( len /= 2);
    }
 
-   public FlatField getData(Object subset) throws Exception {
+   public FlatField getData(Map<String, double[]> subset) throws Exception {
      Set domainSet = makeDomain(subset);
 
-     HashMap new_subset = (HashMap) ((HashMap)subset).clone();
-     new_subset.putAll((HashMap)subset);
+     Map<String, double[]> new_subset = new HashMap<>(subset);
 
-     double[] coords = (double[]) new_subset.get(SwathAdapter.track_name);
+     double[] coords = new_subset.get(SwathAdapter.track_name);
      double[] new_coords = new double[] {0.0, coords[1]/2, 1.0};
 
      new_subset.put(SwathAdapter.track_name, new_coords);

--- a/edu/wisc/ssec/mcidasv/data/hydra/MultiDimensionAdapter.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/MultiDimensionAdapter.java
@@ -64,7 +64,7 @@ public abstract class MultiDimensionAdapter {
      this.init();
    }
 
-   public abstract Map getDefaultSubset();
+   public abstract Map<String, double[]> getDefaultSubset();
 
    public abstract Set makeDomain(Map<String, double[]> subset) throws Exception;
 
@@ -87,9 +87,9 @@ public abstract class MultiDimensionAdapter {
        dimNameMap.put(array_dim_names[i], array_dim_names[i]);
      }
 
-     Iterator iter = metadata.keySet().iterator();
+     Iterator<String> iter = metadata.keySet().iterator();
      while (iter.hasNext()) {
-       String key = (String) iter.next();
+       String key = iter.next();
        Object val = metadata.get(key);
        if (!(val instanceof String)) continue;
        String name = (String) val; 
@@ -102,22 +102,22 @@ public abstract class MultiDimensionAdapter {
 
    }
 
-   public Subset getIndexes(Map select) {
+   public Subset getIndexes(Map<String, double[]> select) {
      Subset subset = new Subset(array_rank);
      int[] start = subset.getStart();
      int[] count = subset.getCount();
      int[] stride = subset.getStride();
 
-     Iterator iter = select.keySet().iterator();
+     Iterator<String> iter = select.keySet().iterator();
      while (iter.hasNext()) {
-       String key = (String) iter.next();
+       String key = iter.next();
        String name = (String) metadata.get(key);
 
        if (name == null) name = key;
 
        for (int kk=0; kk<array_rank; kk++) {
          if (array_dim_names[kk].equals(name)) {
-           double[] coords = (double[]) select.get(key);
+           double[] coords = select.get(key);
 
            if (array_dim_lengths[kk] == 1) {
              start[kk] = 0;
@@ -232,8 +232,8 @@ public abstract class MultiDimensionAdapter {
    }
 
 
-   public Object readArray(Object subset) throws Exception {
-     Subset select = getIndexes((Map)subset);
+   public Object readArray(Map<String, double[]> subset) throws Exception {
+     Subset select = getIndexes(subset);
      int[] start = select.getStart();
      int[] count = select.getCount();
      int[] stride = select.getStride();

--- a/edu/wisc/ssec/mcidasv/data/hydra/MultiDimensionAdapter.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/MultiDimensionAdapter.java
@@ -37,18 +37,19 @@ import visad.Set;
 import java.rmi.RemoteException;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 
 public abstract class MultiDimensionAdapter {
 
    MultiDimensionReader reader = null;
-   HashMap metadata = null;
+   Map<String, Object> metadata = null;
    String arrayName = null;
    String[] array_dim_names = null;
    int[] array_dim_lengths  = null;
    int array_rank;
    Class arrayType;
 
-   HashMap<String, String> dimNameMap = new HashMap<String, String>();
+   Map<String, String> dimNameMap = new HashMap<>();
 
    RealType rangeType;
 
@@ -57,15 +58,15 @@ public abstract class MultiDimensionAdapter {
    public MultiDimensionAdapter() {
    }
 
-   public MultiDimensionAdapter(MultiDimensionReader reader, HashMap metadata) {
+   public MultiDimensionAdapter(MultiDimensionReader reader, Map<String, Object> metadata) {
      this.reader = reader;
      this.metadata = metadata;
      this.init();
    }
 
-   public abstract HashMap getDefaultSubset();
+   public abstract Map getDefaultSubset();
 
-   public abstract Set makeDomain(Object subset) throws Exception;
+   public abstract Set makeDomain(Map<String, double[]> subset) throws Exception;
 
    private void init() {
      this.arrayName = (String) metadata.get("array_name");
@@ -101,7 +102,7 @@ public abstract class MultiDimensionAdapter {
 
    }
 
-   public Subset getIndexes(HashMap select) {
+   public Subset getIndexes(Map select) {
      Subset subset = new Subset(array_rank);
      int[] start = subset.getStart();
      int[] count = subset.getCount();
@@ -135,7 +136,7 @@ public abstract class MultiDimensionAdapter {
      return subset;
    }
 
-   public FlatField getData(Object subset) throws Exception {
+   public FlatField getData(Map<String, double[]> subset) throws Exception {
      Set domainSet = makeDomain(subset);
      return makeFlatField(domainSet, subset);
    }
@@ -157,7 +158,7 @@ public abstract class MultiDimensionAdapter {
      return f_field;
    }
 
-   public FlatField makeFlatField(Set domainSet, Object subset) throws Exception {
+   public FlatField makeFlatField(Set domainSet, Map<String, double[]> subset) throws Exception {
      FlatField f_field = null;
 
      Object range = readArray(subset);
@@ -190,49 +191,49 @@ public abstract class MultiDimensionAdapter {
      this.rangeProcessor = rangeProcessor;
    }
 
-   public float[] processRange(short[] range, Object subset) {
+   public float[] processRange(short[] range, Map<String, double[]> subset) {
      if (rangeProcessor == null) {
        float[] f_range = new float[range.length];
        for (int i=0; i<range.length;i++) f_range[i] = (float) range[i]; 
        return f_range;
      }
      else { 
-       return rangeProcessor.processRange(range, (HashMap)subset);
+       return rangeProcessor.processRange(range, subset);
      }
    }
 
-   public float[] processRange(byte[] range, Object subset) {
+   public float[] processRange(byte[] range, Map<String, double[]> subset) {
      if (rangeProcessor == null) {
        float[] f_range = new float[range.length];
        for (int i=0; i<range.length;i++) f_range[i] = (float) range[i];
        return f_range;
      }
      else {
-       return rangeProcessor.processRange(range, (HashMap)subset);
+       return rangeProcessor.processRange(range, subset);
      }
    }
 
-   public float[] processRange(float[] range, Object subset) {
+   public float[] processRange(float[] range, Map<String, double[]> subset) {
      if (rangeProcessor == null) {
        return range;
      }
      else {
-       return rangeProcessor.processRange(range, (HashMap)subset);
+       return rangeProcessor.processRange(range, subset);
      }
    }
 
-   public double[] processRange(double[] range, Object subset) {
+   public double[] processRange(double[] range, Map<String, double[]> subset) {
      if (rangeProcessor == null) {
        return range;
      }
      else {
-       return rangeProcessor.processRange(range, (HashMap)subset);
+       return rangeProcessor.processRange(range, subset);
      }
    }
 
 
    public Object readArray(Object subset) throws Exception {
-     Subset select = getIndexes((HashMap)subset);
+     Subset select = getIndexes((Map)subset);
      int[] start = select.getStart();
      int[] count = select.getCount();
      int[] stride = select.getStride();
@@ -244,7 +245,7 @@ public abstract class MultiDimensionAdapter {
      return reader;
    }
 
-   public Object getMetadata() {
+   public Map<String, Object> getMetadata() {
      return metadata;
    }
 
@@ -256,17 +257,17 @@ public abstract class MultiDimensionAdapter {
      return rangeType;
    }
    
-   public HashMap getSubsetFromLonLatRect(HashMap subset, double minLat, double maxLat,
-                                                          double minLon, double maxLon) {
+   public Map<String, double[]> getSubsetFromLonLatRect(Map<String, double[]> subset, double minLat, double maxLat,
+                                      double minLon, double maxLon) {
      return subset;
    }
 
-   public HashMap getSubsetFromLonLatRect(double minLat, double maxLat,
+   public Map<String, double[]> getSubsetFromLonLatRect(double minLat, double maxLat,
                                           double minLon, double maxLon) {
      return null;
    }
 
-   public HashMap getSubsetFromLonLatRect(double minLat, double maxLat,
+   public Map<String, double[]> getSubsetFromLonLatRect(double minLat, double maxLat,
                                           double minLon, double maxLon,
                                           int xStride, int yStride, int zStride) {
      return null;

--- a/edu/wisc/ssec/mcidasv/data/hydra/MultiDimensionDataSource.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/MultiDimensionDataSource.java
@@ -40,6 +40,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
+import java.util.Map;
 
 import javax.swing.JComponent;
 import javax.swing.JLabel;
@@ -96,8 +97,8 @@ public class MultiDimensionDataSource extends HydraDataSource {
     protected MultiDimensionReader reader;
 
     protected MultiDimensionAdapter[] adapters = null;
-    protected HashMap[] defaultSubsets = null;
-    private HashMap<String, MultiDimensionAdapter> adapterMap = new HashMap<>();
+    protected Map[] defaultSubsets = null;
+    private Map<String, MultiDimensionAdapter> adapterMap = new HashMap<>();
     protected Hashtable[] propsArray = null;
     protected List[] categoriesArray = null;
 
@@ -106,7 +107,7 @@ public class MultiDimensionDataSource extends HydraDataSource {
 
     private static final String DATA_DESCRIPTION = "Multi Dimension Data";
 
-    private HashMap defaultSubset;
+    private Map<String, double[]> defaultSubset;
     public TrackAdapter track_adapter;
     private MultiSpectralData multiSpectData;
 
@@ -181,8 +182,8 @@ public class MultiDimensionDataSource extends HydraDataSource {
         
         String name = (new File(filename)).getName();
 
-        if ( name.startsWith("MOD04") || name.startsWith("MYD04")) {
-          HashMap table = SwathAdapter.getEmptyMetadataTable();
+        if (name.startsWith("MOD04") || name.startsWith("MYD04")) {
+          Map<String, Object> table = SwathAdapter.getEmptyMetadataTable();
           table.put("array_name", "mod04/Data_Fields/Optical_Depth_Land_And_Ocean");
           table.put("lon_array_name", "mod04/Geolocation_Fields/Longitude");
           table.put("lat_array_name", "mod04/Geolocation_Fields/Latitude");
@@ -199,7 +200,7 @@ public class MultiDimensionDataSource extends HydraDataSource {
           defaultSubset = adapters[0].getDefaultSubset();
           defaultSubsets[0] = defaultSubset;
         }
-        else if ( name.startsWith("MOD06") || name.startsWith("MYD06")) {
+        else if (name.startsWith("MOD06") || name.startsWith("MYD06")) {
           hasImagePreview = true;
           String path = "mod06/Data_Fields/";
           String[] arrayNames = new String[] {"Cloud_Optical_Thickness", "Cloud_Effective_Radius", "Cloud_Water_Path"};
@@ -211,7 +212,7 @@ public class MultiDimensionDataSource extends HydraDataSource {
 
           
           for (int k=0; k<arrayNames.length; k++) {
-            HashMap table = SwathAdapter.getEmptyMetadataTable();
+            Map<String, Object> table = SwathAdapter.getEmptyMetadataTable();
             table.put("array_name", path.concat(arrayNames[k]));
             table.put("lon_array_name", "mod06/Geolocation_Fields/Longitude");
             table.put("lat_array_name", "mod06/Geolocation_Fields/Latitude");
@@ -238,7 +239,7 @@ public class MultiDimensionDataSource extends HydraDataSource {
           }
 
           for (int k=0; k<arrayNames_5km.length; k++) {
-            HashMap table = SwathAdapter.getEmptyMetadataTable();
+            Map<String, Object> table = SwathAdapter.getEmptyMetadataTable();
             table.put("array_name", path.concat(arrayNames_5km[k]));
             table.put("lon_array_name", "mod06/Geolocation_Fields/Longitude");
             table.put("lat_array_name", "mod06/Geolocation_Fields/Latitude");
@@ -269,7 +270,7 @@ public class MultiDimensionDataSource extends HydraDataSource {
 
 
           for (int k=0; k<arrayNames.length; k++) {
-            HashMap table = SwathAdapter.getEmptyMetadataTable();
+            Map<String, Object> table = SwathAdapter.getEmptyMetadataTable();
             table.put("array_name", arrayNames[k]);
             table.put("lon_array_name", "Longitude");
             table.put("lat_array_name", "Latitude");
@@ -299,7 +300,7 @@ public class MultiDimensionDataSource extends HydraDataSource {
           }
 
           for (int k=0; k<arrayNames_5km.length; k++) {
-            HashMap table = SwathAdapter.getEmptyMetadataTable();
+            Map<String, Object> table = SwathAdapter.getEmptyMetadataTable();
             table.put("array_name", arrayNames_5km[k]);
             table.put("lon_array_name", "Longitude");
             table.put("lat_array_name", "Latitude");
@@ -329,7 +330,7 @@ public class MultiDimensionDataSource extends HydraDataSource {
          propsArray = new Hashtable[4]; 
          
          
-         HashMap table = ProfileAlongTrack.getEmptyMetadataTable();
+         Map<String, Object> table = ProfileAlongTrack.getEmptyMetadataTable();
          table.put(ProfileAlongTrack.array_name, "Total_Attenuated_Backscatter_532");
          table.put(ProfileAlongTrack.ancillary_file_name, "/edu/wisc/ssec/mcidasv/data/hydra/resources/calipso/altitude");
          table.put(ProfileAlongTrack.trackDim_name, "dim0");
@@ -340,7 +341,7 @@ public class MultiDimensionDataSource extends HydraDataSource {
          table.put("array_dimension_names", new String[] {"dim0", "dim1"}); 
          ProfileAlongTrack adapter = new Calipso2D(reader, table);
          ProfileAlongTrack3D adapter3D = new ProfileAlongTrack3D(adapter);
-         HashMap subset = adapter.getDefaultSubset();
+         Map<String, double[]> subset = adapter.getDefaultSubset();
          adapters[0] = adapter3D;
          defaultSubset = subset;
          defaultSubsets[0] = defaultSubset;
@@ -448,7 +449,7 @@ public class MultiDimensionDataSource extends HydraDataSource {
          defaultSubsets = new HashMap[2];
          propsArray = new Hashtable[2];
 
-         HashMap table = ProfileAlongTrack.getEmptyMetadataTable();
+         Map table = ProfileAlongTrack.getEmptyMetadataTable();
          table.put(ProfileAlongTrack.array_name, "2B-GEOPROF/Data_Fields/Radar_Reflectivity");
          table.put(ProfileAlongTrack.range_name, "2B-GEOPROF_RadarReflectivity");
          table.put(ProfileAlongTrack.scale_name, "factor");
@@ -464,7 +465,7 @@ public class MultiDimensionDataSource extends HydraDataSource {
          table.put(ProfileAlongTrack.product_name, "2B-GEOPROF");
          ProfileAlongTrack adapter = new CloudSat2D(reader, table);
          ProfileAlongTrack3D adapter3D = new ProfileAlongTrack3D(adapter);
-         HashMap subset = adapter.getDefaultSubset();
+         Map<String, double[]> subset = adapter.getDefaultSubset();
          adapters[0] = adapter3D;
          defaultSubset = subset;
          defaultSubsets[0] = defaultSubset;
@@ -509,7 +510,7 @@ public class MultiDimensionDataSource extends HydraDataSource {
          hasTrackPreview = true;
        }
        else if ( name.startsWith("MHSx_xxx_1B") && name.endsWith("h5")) {
-          HashMap table = SwathAdapter.getEmptyMetadataTable();
+          Map<String, Object> table = SwathAdapter.getEmptyMetadataTable();
           table.put("array_name", "U-MARF/EPS/MHSx_xxx_1B/DATA/Channel1");
           table.put("lon_array_name", "U-MARF/EPS/IASI_xxx_1C/DATA/IMAGE_LON_ARRAY");
           table.put("lat_array_name", "U-MARF/EPS/IASI_xxx_1C/DATA/IMAGE_LAT_ARRAY");
@@ -520,7 +521,7 @@ public class MultiDimensionDataSource extends HydraDataSource {
           table.put("product_name", "MHSx_xxx_1B");
           SwathAdapter swathAdapter = new SwathAdapter(reader, table);
           adapters[0] = swathAdapter;
-          HashMap subset = swathAdapter.getDefaultSubset();
+          Map<String, double[]> subset = swathAdapter.getDefaultSubset();
           defaultSubset = subset;
           defaultSubsets[0] = defaultSubset;
           categories = DataCategory.parseCategories("2D grid;GRID-2D;");
@@ -543,7 +544,7 @@ public class MultiDimensionDataSource extends HydraDataSource {
          propsArray = new Hashtable[arrayNames.length]; 
 
          for (int k=0; k<arrayNames.length; k++) {
-           HashMap swthTable = SwathAdapter.getEmptyMetadataTable();
+           Map<String, Object> swthTable = SwathAdapter.getEmptyMetadataTable();
            swthTable.put("array_name", arrayNames[k]);
            swthTable.put("lon_array_name", "pixel_longitude");
            swthTable.put("lat_array_name", "pixel_latitude");
@@ -561,7 +562,7 @@ public class MultiDimensionDataSource extends HydraDataSource {
            swthTable.put("unpack", "unpack");
 
            SwathAdapter swathAdapter0 = new SwathAdapter(reader, swthTable);
-           HashMap subset = swathAdapter0.getDefaultSubset();
+           Map<String, double[]> subset = swathAdapter0.getDefaultSubset();
            defaultSubset = subset;
            adapters[k] = swathAdapter0;
            defaultSubsets[k] = defaultSubset;
@@ -577,7 +578,7 @@ public class MultiDimensionDataSource extends HydraDataSource {
          propsArray = new Hashtable[arrayNames.length];
          
          for (int k=0; k<arrayNames.length; k++) {
-           HashMap swthTable = SwathAdapter.getEmptyMetadataTable();
+           Map<String, Object> swthTable = SwathAdapter.getEmptyMetadataTable();
            swthTable.put("array_name", arrayNames[k]);
            swthTable.put("lon_array_name", "Longitude");
            swthTable.put("lat_array_name", "Latitude");
@@ -591,7 +592,7 @@ public class MultiDimensionDataSource extends HydraDataSource {
 
            SwathAdapter swathAdapter0 = new SwathAdapter(reader, swthTable);
            swathAdapter0.setDefaultStride(5);
-           HashMap subset = swathAdapter0.getDefaultSubset();
+           Map<String, double[]> subset = swathAdapter0.getDefaultSubset();
            defaultSubset = subset;
            adapters[k] = swathAdapter0;
            defaultSubsets[k] = defaultSubset;
@@ -608,7 +609,7 @@ public class MultiDimensionDataSource extends HydraDataSource {
          propsArray = new Hashtable[arrayNames.length];
 
          for (int k=0; k<arrayNames.length; k++) {
-           HashMap swthTable = SwathAdapter.getEmptyMetadataTable();
+           Map<String, Object> swthTable = SwathAdapter.getEmptyMetadataTable();
            swthTable.put("array_name", arrayNames[k]);
            swthTable.put("lon_array_name", "Longitude");
            swthTable.put("lat_array_name", "Latitude");
@@ -622,7 +623,7 @@ public class MultiDimensionDataSource extends HydraDataSource {
 
            SwathAdapter swathAdapter0 = new SwathAdapter(reader, swthTable);
            swathAdapter0.setDefaultStride(5);
-           HashMap subset = swathAdapter0.getDefaultSubset();
+           Map<String, double[]> subset = swathAdapter0.getDefaultSubset();
            defaultSubset = subset;
            adapters[k] = swathAdapter0;
            defaultSubsets[k] = defaultSubset;
@@ -639,7 +640,7 @@ public class MultiDimensionDataSource extends HydraDataSource {
          propsArray = new Hashtable[arrayNames.length];
 
          for (int k=0; k<arrayNames.length; k++) {
-           HashMap swthTable = SwathAdapter.getEmptyMetadataTable();
+           Map<String, Object> swthTable = SwathAdapter.getEmptyMetadataTable();
            swthTable.put("array_name", arrayNames[k]);
            swthTable.put("lon_array_name", "Longitude");
            swthTable.put("lat_array_name", "Latitude");
@@ -658,7 +659,7 @@ public class MultiDimensionDataSource extends HydraDataSource {
 
            SwathAdapter swathAdapter0 = new SwathAdapter(reader, swthTable);
            swathAdapter0.setDefaultStride(5);
-           HashMap subset = swathAdapter0.getDefaultSubset();
+           Map<String, double[]> subset = swathAdapter0.getDefaultSubset();
            defaultSubset = subset;
            adapters[k] = swathAdapter0;
            defaultSubsets[k] = defaultSubset;
@@ -674,7 +675,7 @@ public class MultiDimensionDataSource extends HydraDataSource {
          propsArray = new Hashtable[arrayNames.length];
 
          for (int k=0; k<arrayNames.length; k++) {
-           HashMap swthTable = SwathAdapter.getEmptyMetadataTable();
+           Map<String, Object> swthTable = SwathAdapter.getEmptyMetadataTable();
            swthTable.put("array_name", arrayNames[k]);
            swthTable.put("lon_array_name", "lon");
            swthTable.put("lat_array_name", "lat");
@@ -686,7 +687,7 @@ public class MultiDimensionDataSource extends HydraDataSource {
 
            SwathAdapter swathAdapter0 = new SwathAdapter(reader, swthTable);
            swathAdapter0.setDefaultStride(1);
-           HashMap subset = swathAdapter0.getDefaultSubset();
+           Map<String, double[]> subset = swathAdapter0.getDefaultSubset();
            defaultSubset = subset;
            adapters[k] = swathAdapter0;
            defaultSubsets[k] = defaultSubset;
@@ -704,7 +705,7 @@ public class MultiDimensionDataSource extends HydraDataSource {
          propsArray = new Hashtable[arrayNames.length]; 
 
          for (int k=0; k<arrayNames.length; k++) {
-           HashMap swthTable = SwathAdapter.getEmptyMetadataTable();
+           Map<String, Object> swthTable = SwathAdapter.getEmptyMetadataTable();
            swthTable.put("array_name", arrayNames[k]);
            swthTable.put("lon_array_name", "pixel_longitude");
            swthTable.put("lat_array_name", "pixel_latitude");
@@ -723,7 +724,7 @@ public class MultiDimensionDataSource extends HydraDataSource {
 
            SwathAdapter swathAdapter0 = new SwathAdapter(reader, swthTable);
            swathAdapter0.setDefaultStride(2);
-           HashMap subset = swathAdapter0.getDefaultSubset();
+           Map<String, double[]> subset = swathAdapter0.getDefaultSubset();
            defaultSubset = subset;
            adapters[k] = swathAdapter0;
            defaultSubsets[k] = defaultSubset;
@@ -814,7 +815,7 @@ public class MultiDimensionDataSource extends HydraDataSource {
       filename = name;
     }
 
-    public HashMap getSubsetFromLonLatRect(MultiDimensionSubset select, GeoSelection geoSelection) {
+    public Map getSubsetFromLonLatRect(MultiDimensionSubset select, GeoSelection geoSelection) {
       GeoLocationInfo ginfo = geoSelection.getBoundingBox();
       return adapters[0].getSubsetFromLonLatRect(select.getSubset(), ginfo.getMinLat(), ginfo.getMaxLat(),
                                         ginfo.getMinLon(), ginfo.getMaxLon());
@@ -867,7 +868,7 @@ public class MultiDimensionDataSource extends HydraDataSource {
           return data;
         }
 
-        HashMap subset = null;
+        Map subset = null;
         MultiDimensionSubset select = null;
 
         Hashtable table = dataChoice.getProperties();
@@ -913,8 +914,8 @@ public class MultiDimensionDataSource extends HydraDataSource {
         return data;
     }
 
-    protected Data applyProperties(Data data, Hashtable requestProperties, HashMap subset) 
-          throws VisADException, RemoteException {
+    protected Data applyProperties(Data data, Hashtable requestProperties, Map<String, double[]> subset)
+          throws VisADException, RemoteException, Exception {
       Data new_data = data;
 
       if (requestProperties == null) {
@@ -1004,7 +1005,7 @@ public class MultiDimensionDataSource extends HydraDataSource {
     }
 
     private ArrayAdapter createTrackVertArrayAdapter(String variableName) {
-        HashMap table = SwathAdapter.getEmptyMetadataTable();
+        Map<String, Object> table = SwathAdapter.getEmptyMetadataTable();
 
         String trackDimName = getTrackDimensionName(variableName);
         String vertDimName = getVerticalDimensionName(variableName);

--- a/edu/wisc/ssec/mcidasv/data/hydra/MultiDimensionDataSource.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/MultiDimensionDataSource.java
@@ -449,7 +449,7 @@ public class MultiDimensionDataSource extends HydraDataSource {
          defaultSubsets = new HashMap[2];
          propsArray = new Hashtable[2];
 
-         Map table = ProfileAlongTrack.getEmptyMetadataTable();
+         Map<String, Object> table = ProfileAlongTrack.getEmptyMetadataTable();
          table.put(ProfileAlongTrack.array_name, "2B-GEOPROF/Data_Fields/Radar_Reflectivity");
          table.put(ProfileAlongTrack.range_name, "2B-GEOPROF_RadarReflectivity");
          table.put(ProfileAlongTrack.scale_name, "factor");
@@ -815,7 +815,7 @@ public class MultiDimensionDataSource extends HydraDataSource {
       filename = name;
     }
 
-    public Map getSubsetFromLonLatRect(MultiDimensionSubset select, GeoSelection geoSelection) {
+    public Map<String, double[]> getSubsetFromLonLatRect(MultiDimensionSubset select, GeoSelection geoSelection) {
       GeoLocationInfo ginfo = geoSelection.getBoundingBox();
       return adapters[0].getSubsetFromLonLatRect(select.getSubset(), ginfo.getMinLat(), ginfo.getMaxLat(),
                                         ginfo.getMinLon(), ginfo.getMaxLon());
@@ -868,7 +868,7 @@ public class MultiDimensionDataSource extends HydraDataSource {
           return data;
         }
 
-        Map subset = null;
+        Map<String, double[]> subset = null;
         MultiDimensionSubset select = null;
 
         Hashtable table = dataChoice.getProperties();

--- a/edu/wisc/ssec/mcidasv/data/hydra/MultiDimensionSubset.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/MultiDimensionSubset.java
@@ -32,6 +32,7 @@ import ucar.unidata.data.DataSelection;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 
 
@@ -46,7 +47,7 @@ public class MultiDimensionSubset extends DataSelection {
     super();
   }
 
-  public MultiDimensionSubset(HashMap subset) {
+  public MultiDimensionSubset(Map<String, double[]> subset) {
     super();
     coords = new double[subset.size()][];
     keys = new String[subset.size()];
@@ -78,8 +79,8 @@ public class MultiDimensionSubset extends DataSelection {
     this.keys = keys;
   }
 
-  public HashMap getSubset() {
-    HashMap hmap = new HashMap();
+  public Map<String, double[]> getSubset() {
+    Map<String, double[]> hmap = new HashMap<>();
     for (int k=0; k<keys.length; k++) {
       double[] new_coords = new double[coords[k].length];
       System.arraycopy(coords[k],0,new_coords,0,new_coords.length);

--- a/edu/wisc/ssec/mcidasv/data/hydra/MultiSpectralAggr.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/MultiSpectralAggr.java
@@ -48,6 +48,7 @@ import java.rmi.RemoteException;
 import java.util.HashMap;
 import java.util.ArrayList;
 import java.awt.geom.Rectangle2D;
+import java.util.Map;
 
 import visad.georef.MapProjection;
 import visad.CachingCoordinateSystem;
@@ -84,8 +85,8 @@ public class MultiSpectralAggr extends MultiSpectralData {
 
     if (adapters[0].spectrumAdapter.hasBandNames()) {
       hasBandNames = true;
-      bandNameList = new ArrayList<String>();
-      bandNameMap = new HashMap<String, Float>();
+      bandNameList = new ArrayList<>();
+      bandNameMap = new HashMap<>();
       for (int k=0; k<numAdapters; k++) {
         bandNameList.addAll(adapters[k].spectrumAdapter.getBandNames());
         bandNameMap.putAll(adapters[k].spectrumAdapter.getBandNameMap());
@@ -159,7 +160,7 @@ public class MultiSpectralAggr extends MultiSpectralData {
     return spectrum;
   }
 
-  public FlatField getImage(HashMap subset) throws Exception {
+  public FlatField getImage(Map<String, double[]> subset) throws Exception {
     int channelIndex = (int) ((double[])subset.get(SpectrumAdapter.channelIndex_name))[0];
     
     int idx = sort_indexes[channelIndex];
@@ -177,7 +178,7 @@ public class MultiSpectralAggr extends MultiSpectralData {
     return image;
   }
 
-  public FlatField getImage(float channel, HashMap subset) throws Exception {
+  public FlatField getImage(float channel, Map<String, double[]> subset) throws Exception {
     int channelIndex = aggrDomain.valueToIndex(new float[][] {{channel}})[0];
 
     int idx = sort_indexes[channelIndex];
@@ -204,8 +205,8 @@ public class MultiSpectralAggr extends MultiSpectralData {
     return (aggrDomain.indexToValue(new int[] {index}))[0][0];
   }
 
-  public HashMap getDefaultSubset() {
-    HashMap subset = adapters[0].getDefaultSubset();
+  public Map<String, double[]> getDefaultSubset() {
+    Map<String, double[]> subset = adapters[0].getDefaultSubset();
     double chanIdx = 0;
     try {
       chanIdx = getChannelIndexFromWavenumber(init_wavenumber);

--- a/edu/wisc/ssec/mcidasv/data/hydra/MultiSpectralData.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/MultiSpectralData.java
@@ -33,6 +33,8 @@ import java.rmi.RemoteException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 import visad.CoordinateSystem;
 import visad.FlatField;
@@ -55,8 +57,8 @@ public class MultiSpectralData extends MultiDimensionAdapter {
   SpectrumAdapter spectrumAdapter = null;
   CoordinateSystem cs = null;
 
-  HashMap spectrumSelect = null;
-  HashMap swathSelect = null;
+  Map<String, double[]> spectrumSelect = null;
+  Map swathSelect = null;
 
   String sensorName = null;
   String platformName = null;
@@ -70,8 +72,8 @@ public class MultiSpectralData extends MultiDimensionAdapter {
   float[] dataRange = new float[] {180f, 320f};
 
   boolean hasBandNames = false;
-  ArrayList<String> bandNameList = null;
-  HashMap<String, Float> bandNameMap = null;
+  List<String> bandNameList = null;
+  Map<String, Float> bandNameMap = null;
 
   
   public MultiSpectralData(SwathAdapter swathAdapter, SpectrumAdapter spectrumAdapter,
@@ -148,7 +150,7 @@ public class MultiSpectralData extends MultiDimensionAdapter {
     return convertSpectrum(spectrum, paramName);
   }
 
-  public FlatField getImage(HashMap subset) 
+  public FlatField getImage(Map<String, double[]> subset)
     throws Exception, VisADException, RemoteException {
     FlatField image = swathAdapter.getData(subset);
     cs = ((RealTupleType) ((FunctionType)image.getType()).getDomain()).getCoordinateSystem();
@@ -159,7 +161,7 @@ public class MultiSpectralData extends MultiDimensionAdapter {
     return convertImage(image, channel, paramName);
   }
 
-  public FlatField getImage(float channel, HashMap subset) 
+  public FlatField getImage(float channel, Map<String, double[]> subset)
       throws Exception, VisADException, RemoteException {
     if (spectrumAdapter == null) return getImage(subset);
     int channelIndex = spectrumAdapter.getChannelIndexFromWavenumber(channel);
@@ -170,11 +172,11 @@ public class MultiSpectralData extends MultiDimensionAdapter {
     return convertImage(image, channel, paramName);
   }
 
-  public FlatField getData(Object subset) throws Exception {
-    return getImage((HashMap)subset);
+  public FlatField getData(Map<String, double[]> subset) throws Exception {
+    return getImage(subset);
   }
 
-  public Set makeDomain(Object subset) throws Exception {
+  public Set makeDomain(Map<String, double[]> subset) throws Exception {
     throw new Exception("makeDomain unimplented");
   } 
 
@@ -273,11 +275,11 @@ public class MultiSpectralData extends MultiDimensionAdapter {
     return hasBandNames;
   }
 
-  public ArrayList<String> getBandNames() {
+  public List<String> getBandNames() {
     return bandNameList;
   }
 
-  public HashMap<String, Float> getBandNameMap() {
+  public Map<String, Float> getBandNameMap() {
     return bandNameMap;
   }
 
@@ -342,7 +344,7 @@ public class MultiSpectralData extends MultiDimensionAdapter {
     return null;
   }
 
-  public Rectangle2D getLonLatBoundingBox(HashMap subset) 
+  public Rectangle2D getLonLatBoundingBox(Map<String, double[]> subset)
       throws Exception {
     Set domainSet = swathAdapter.makeDomain(subset);
     return getLonLatBoundingBox(domainSet);
@@ -725,8 +727,8 @@ public class MultiSpectralData extends MultiDimensionAdapter {
     return new_values;
   }
 
-  public HashMap getDefaultSubset() {
-    HashMap subset = swathAdapter.getDefaultSubset();
+  public Map<String, double[]> getDefaultSubset() {
+    Map subset = swathAdapter.getDefaultSubset();
     double chanIdx=0;
 
     try {

--- a/edu/wisc/ssec/mcidasv/data/hydra/MultiSpectralData.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/MultiSpectralData.java
@@ -728,7 +728,7 @@ public class MultiSpectralData extends MultiDimensionAdapter {
   }
 
   public Map<String, double[]> getDefaultSubset() {
-    Map subset = swathAdapter.getDefaultSubset();
+    Map<String, double[]> subset = swathAdapter.getDefaultSubset();
     double chanIdx=0;
 
     try {

--- a/edu/wisc/ssec/mcidasv/data/hydra/MultiSpectralDataSource.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/MultiSpectralDataSource.java
@@ -40,6 +40,8 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import javax.swing.JComponent;
 import javax.swing.JLabel;
@@ -97,13 +99,13 @@ public class MultiSpectralDataSource extends HydraDataSource {
     private static final String DATA_DESCRIPTION = "Multi Dimension Data";
 
 
-    private HashMap defaultSubset;
+    private Map<String, double[]> defaultSubset;
     private SwathAdapter swathAdapter;
     private SpectrumAdapter spectrumAdapter;
     private MultiSpectralData multiSpectData;
 
-    private ArrayList<MultiSpectralData> multiSpectData_s = new ArrayList<MultiSpectralData>();
-    private HashMap<String, MultiSpectralData> adapterMap = new HashMap<String, MultiSpectralData>();
+    private List<MultiSpectralData> multiSpectData_s = new ArrayList<>();
+    private Map<String, MultiSpectralData> adapterMap = new HashMap<>();
 
     private List categories;
     private boolean hasImagePreview = false;
@@ -168,12 +170,11 @@ public class MultiSpectralDataSource extends HydraDataSource {
     public void setup() throws Exception {
         String name = (new File(filename)).getName();
     	// aggregations will use sets of NetCDFFile readers
-    	ArrayList<NetCDFFile> ncdfal = new ArrayList<NetCDFFile>();
+    	List<NetCDFFile> ncdfal = new ArrayList<>();
 
         try {
           if (name.startsWith("NSS.HRPT.NP") && name.endsWith("obs.hdf")) { // get file union
-            String other = new String(filename);
-            other = other.replace("obs", "nav");
+            String other = filename.replace("obs", "nav");
             reader = NetCDFFile.makeUnion(filename, other);
           }
           /**
@@ -199,7 +200,7 @@ public class MultiSpectralDataSource extends HydraDataSource {
         	logger.error("Cannot create NetCDF reader for file: " + filename);
         }
                                                                                                                                                      
-        Hashtable<String, String[]> properties = new Hashtable<String, String[]>(); 
+        Hashtable<String, String[]> properties = new Hashtable<>();
 
         multiSpectData_s.clear();
 
@@ -209,7 +210,7 @@ public class MultiSpectralDataSource extends HydraDataSource {
         	// index 0: Rad, index 1: BT
         	int choiceCount = 2;
         	for (int i = 0; i < choiceCount; i++) {
-        		HashMap table = SpectrumAdapter.getEmptyMetadataTable();
+                Map<String, Object> table = SpectrumAdapter.getEmptyMetadataTable();
         		if (i == 0) {
         			table.put(SpectrumAdapter.array_name, "L1B_AIRS_Science/Data_Fields/radiances");
         			table.put(SpectrumAdapter.range_name, "Radiance");
@@ -241,7 +242,7 @@ public class MultiSpectralDataSource extends HydraDataSource {
         		table.put(SpectrumAdapter.channelIndex_name, "Channel"); //- think about this?
 
         		SwathAdapter swathAdapter = new SwathAdapter(reader, table);
-        		HashMap subset = swathAdapter.getDefaultSubset();
+        		Map<String, double[]> subset = swathAdapter.getDefaultSubset();
         		subset.put(SpectrumAdapter.channelIndex_name, new double[] {793,793,1});
         		defaultSubset = subset;
 
@@ -262,7 +263,7 @@ public class MultiSpectralDataSource extends HydraDataSource {
         	}
         }
        else if ( name.startsWith("IASI_xxx_1C") && name.endsWith("h5")) {
-          HashMap table = SpectrumAdapter.getEmptyMetadataTable();
+          Map<String, Object> table = SpectrumAdapter.getEmptyMetadataTable();
           table.put(SpectrumAdapter.array_name, "U-MARF/EPS/IASI_xxx_1C/DATA/SPECT_DATA");
           table.put(SpectrumAdapter.channelIndex_name, "dim2");
           table.put(SpectrumAdapter.x_dim_name, "dim1");
@@ -280,7 +281,7 @@ public class MultiSpectralDataSource extends HydraDataSource {
           table.put("product_name", "IASI_L1C_xxx");
           table.put(SpectrumAdapter.channelIndex_name, "dim2");
           swathAdapter = new IASI_L1C_SwathAdapter(reader, table);
-          HashMap subset = swathAdapter.getDefaultSubset();
+          Map<String, double[]> subset = swathAdapter.getDefaultSubset();
           subset.put(SpectrumAdapter.channelIndex_name, new double[] {793,793,1});
           defaultSubset = subset;
           multiSpectData = new MultiSpectralData(swathAdapter, spectrumAdapter);
@@ -291,7 +292,7 @@ public class MultiSpectralDataSource extends HydraDataSource {
           multiSpectData_s.add(multiSpectData);
        }
        else if ( name.startsWith("IASI")) {
-          HashMap table = SpectrumAdapter.getEmptyMetadataTable();
+          Map<String, Object> table = SpectrumAdapter.getEmptyMetadataTable();
           table.put(SpectrumAdapter.array_name, "observations");
           table.put(SpectrumAdapter.channelIndex_name, "obsChannelIndex");
           table.put(SpectrumAdapter.x_dim_name, "obsElement");
@@ -309,7 +310,7 @@ public class MultiSpectralDataSource extends HydraDataSource {
           table.put("geo_Track", "obsLine");
           table.put(SpectrumAdapter.channelIndex_name, "obsChannelIndex"); //- think about this?
           swathAdapter = new SwathAdapter(reader, table);
-          HashMap subset = swathAdapter.getDefaultSubset();
+          Map<String, double[]> subset = swathAdapter.getDefaultSubset();
           subset.put(SpectrumAdapter.channelIndex_name, new double[] {793,793,1});
           defaultSubset = subset;
           multiSpectData = new MultiSpectralData(swathAdapter, spectrumAdapter);
@@ -322,7 +323,7 @@ public class MultiSpectralDataSource extends HydraDataSource {
        else if (name.startsWith("MOD021KM") || name.startsWith("MYD021KM") || 
                (name.startsWith("a1") && (name.indexOf("1000m") > 0)) || 
                (name.startsWith("t1") && (name.indexOf("1000m") > 0)) ) {
-         HashMap table = SwathAdapter.getEmptyMetadataTable();
+         Map<String, Object> table = SwathAdapter.getEmptyMetadataTable();
          table.put("array_name", "MODIS_SWATH_Type_L1B/Data_Fields/EV_1KM_Emissive");
          table.put("lon_array_name", "MODIS_SWATH_Type_L1B/Geolocation_Fields/Longitude");
          table.put("lat_array_name", "MODIS_SWATH_Type_L1B/Geolocation_Fields/Latitude");
@@ -347,7 +348,7 @@ public class MultiSpectralDataSource extends HydraDataSource {
          
          // initialize the aggregation reader object
          logger.debug("Trying to create MODIS 1K GranuleAggregation reader...");
-         LinkedHashSet<String> products = new LinkedHashSet<String>();
+         Set<String> products = new LinkedHashSet<>();
          products.add((String) table.get("array_name"));
          products.add("MODIS_SWATH_Type_L1B/Data_Fields/EV_1KM_RefSB");
          products.add("MODIS_SWATH_Type_L1B/Data_Fields/EV_250_Aggr1km_RefSB");
@@ -367,9 +368,9 @@ public class MultiSpectralDataSource extends HydraDataSource {
 
          swathAdapter = new SwathAdapter(reader, table);
          swathAdapter.setDefaultStride(10);
-         logger.debug("Trying to create MODIS 1K SwathAdapter..."); 
+         logger.debug("Trying to create MODIS 1K SwathAdapter...");
 
-         HashMap subset = swathAdapter.getDefaultSubset();
+         Map<String, double[]> subset = swathAdapter.getDefaultSubset();
 
          table = SpectrumAdapter.getEmptyMetadataTable();
          table.put(SpectrumAdapter.array_name, "MODIS_SWATH_Type_L1B/Data_Fields/EV_1KM_Emissive");
@@ -518,7 +519,7 @@ public class MultiSpectralDataSource extends HydraDataSource {
        else if (name.startsWith("MOD02QKM") || name.startsWith("MYD02QKM") ||
                (name.startsWith("a1") && (name.indexOf("250m") > 0)) ||
                (name.startsWith("t1") && (name.indexOf("250m") > 0)) ) {
-         HashMap table = SwathAdapter.getEmptyMetadataTable();
+         Map<String, Object> table = SwathAdapter.getEmptyMetadataTable();
          table.put("array_name", "MODIS_SWATH_Type_L1B/Data_Fields/EV_250_RefSB");
          table.put("lon_array_name", "MODIS_SWATH_Type_L1B/Geolocation_Fields/Longitude");
          table.put("lat_array_name", "MODIS_SWATH_Type_L1B/Geolocation_Fields/Latitude");
@@ -582,7 +583,7 @@ public class MultiSpectralDataSource extends HydraDataSource {
        else if (name.startsWith("MOD02HKM") || name.startsWith("MYD02HKM") ||
                (name.startsWith("a1") && (name.indexOf("500m") > 0)) ||
                (name.startsWith("t1") && (name.indexOf("500m") > 0)) ) {
-         HashMap table = SwathAdapter.getEmptyMetadataTable();
+         Map<String, Object> table = SwathAdapter.getEmptyMetadataTable();
          table.put("array_name", "MODIS_SWATH_Type_L1B/Data_Fields/EV_250_Aggr500_RefSB");
          table.put("lon_array_name", "MODIS_SWATH_Type_L1B/Geolocation_Fields/Longitude");
          table.put("lat_array_name", "MODIS_SWATH_Type_L1B/Geolocation_Fields/Latitude");
@@ -687,7 +688,7 @@ public class MultiSpectralDataSource extends HydraDataSource {
          multiSpectData_s.add(null);
        }
        else if (name.startsWith("NSS.HRPT") && name.endsWith("level2.hdf")) {
-         HashMap swthTable = SwathAdapter.getEmptyMetadataTable();
+         Map<String, Object> swthTable = SwathAdapter.getEmptyMetadataTable();
          swthTable.put("array_name", "temp_3_75um_nom");
          swthTable.put("lon_array_name", "longitude");
          swthTable.put("lat_array_name", "latitude");
@@ -707,10 +708,10 @@ public class MultiSpectralDataSource extends HydraDataSource {
 
          SwathAdapter swathAdapter0 = new SwathAdapter(reader, swthTable);
          swathAdapter0.setDefaultStride(10);
-         HashMap subset = swathAdapter0.getDefaultSubset();
+         Map<String, double[]> subset = swathAdapter0.getDefaultSubset();
          defaultSubset = subset;
 
-         HashMap specTable = SpectrumAdapter.getEmptyMetadataTable();
+         Map<String, Object> specTable = SpectrumAdapter.getEmptyMetadataTable();
          specTable.put(SpectrumAdapter.array_name, "temp_3_75um_nom");
          specTable.put(SpectrumAdapter.x_dim_name, "pixel_elements_along_scan_direction");
          specTable.put(SpectrumAdapter.y_dim_name, "scan_lines_along_track_direction");
@@ -721,7 +722,7 @@ public class MultiSpectralDataSource extends HydraDataSource {
 
          MultiSpectralData multiSpectData0 = new MultiSpectralData(swathAdapter0, spectrumAdapter0, "BrightnessTemp", "BrightnessTemp", null, null);
 
-         HashMap table = SwathAdapter.getEmptyMetadataTable();
+         Map<String, Object> table = SwathAdapter.getEmptyMetadataTable();
          table.put("array_name", "temp_11_0um_nom");
          table.put("lon_array_name", "longitude");
          table.put("lat_array_name", "latitude");
@@ -847,7 +848,7 @@ public class MultiSpectralDataSource extends HydraDataSource {
          hasChannelSelect = true;
        }
        else {
-          HashMap table = SwathAdapter.getEmptyMetadataTable();
+          Map<String, Object> table = SwathAdapter.getEmptyMetadataTable();
           table.put("array_name", "MODIS_SWATH_Type_L1B/Data_Fields/EV_1KM_Emissive");
           table.put("lon_array_name", "pixel_longitude");
           table.put("lat_array_name", "pixel_latitude");
@@ -975,7 +976,7 @@ public class MultiSpectralDataSource extends HydraDataSource {
     }
    */
 
-    public synchronized Data getData(String name, HashMap subset) throws VisADException, RemoteException {
+    public synchronized Data getData(String name, Map<String, double[]> subset) throws VisADException, RemoteException {
       MultiSpectralData msd =  getMultiSpectralData(name);
       Data data = null;
       try {
@@ -1025,7 +1026,7 @@ public class MultiSpectralDataSource extends HydraDataSource {
         Data data = null;
 
         try {
-            HashMap subset = null;
+            Map<String, double[]> subset = null;
             if (ginfo != null) {
               subset = swathAdapter.getSubsetFromLonLatRect(ginfo.getMinLat(), ginfo.getMaxLat(),
                                         ginfo.getMinLon(), ginfo.getMaxLon());
@@ -1055,7 +1056,7 @@ public class MultiSpectralDataSource extends HydraDataSource {
                     }
                     if (props.containsKey(SpectrumAdapter.channelIndex_name)) {
                       int idx = ((Integer) props.get(SpectrumAdapter.channelIndex_name)).intValue();
-                      double[] coords = (double[]) subset.get(SpectrumAdapter.channelIndex_name);
+                      double[] coords = subset.get(SpectrumAdapter.channelIndex_name);
                       if (coords == null) {
                         coords = new double[] {(double)idx, (double)idx, (double)1};
                         subset.put(SpectrumAdapter.channelIndex_name, coords);
@@ -1084,7 +1085,7 @@ public class MultiSpectralDataSource extends HydraDataSource {
         return data;
     }
 
-    public MapProjection getDataProjection(HashMap subset) {
+    public MapProjection getDataProjection(Map<String, double[]> subset) {
       MapProjection mp = null;
       try {
         Rectangle2D rect =  multiSpectData.getLonLatBoundingBox(subset);
@@ -1096,7 +1097,7 @@ public class MultiSpectralDataSource extends HydraDataSource {
       return mp;
     }
 
-    protected Data applyProperties(Data data, Hashtable requestProperties, HashMap subset) 
+    protected Data applyProperties(Data data, Hashtable requestProperties, Map<String, double[]> subset)
           throws VisADException, RemoteException {
       Data new_data = data;
 

--- a/edu/wisc/ssec/mcidasv/data/hydra/Navigation.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/Navigation.java
@@ -31,9 +31,11 @@ package edu.wisc.ssec.mcidasv.data.hydra;
 import visad.CoordinateSystem;
 import visad.Linear2DSet;
 
+import java.util.Map;
+
 public interface Navigation {
 
-  public CoordinateSystem getVisADCoordinateSystem(Linear2DSet domain, Object subset) throws Exception;
+  public CoordinateSystem getVisADCoordinateSystem(Linear2DSet domain, Map<String, double[]> subset) throws Exception;
 
 }
 

--- a/edu/wisc/ssec/mcidasv/data/hydra/ProfileAlongTrack.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/ProfileAlongTrack.java
@@ -46,6 +46,7 @@ import java.rmi.RemoteException;
 
 import java.util.Hashtable;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.StringTokenizer;
 
 import java.io.BufferedReader;
@@ -106,15 +107,15 @@ public abstract class ProfileAlongTrack extends MultiDimensionAdapter {
 
       CoordinateSystem cs = null;
 
-      public static HashMap getEmptySubset() {
-        HashMap<String, double[]> subset = new HashMap<String, double[]>();
+      public static Map<String, double[]> getEmptySubset() {
+        Map<String, double[]> subset = new HashMap<>();
         subset.put(trackDim_name, new double[3]);
         subset.put(vertDim_name, new double[3]);
         return subset;
       }
 
-      public static HashMap getEmptyMetadataTable() {
-        HashMap<String, String> metadata = new HashMap<String, String>();
+      public static Map<String, Object> getEmptyMetadataTable() {
+        Map<String, Object> metadata = new HashMap<>();
         metadata.put(array_name, null);
         metadata.put(trackDim_name, null);
         metadata.put(vertDim_name, null);
@@ -138,11 +139,11 @@ public abstract class ProfileAlongTrack extends MultiDimensionAdapter {
       public ProfileAlongTrack() {
       }
 
-      public ProfileAlongTrack(MultiDimensionReader reader, HashMap metadata) {
+      public ProfileAlongTrack(MultiDimensionReader reader, Map<String, Object> metadata) {
         this(reader, metadata, true);
       }
 
-      public ProfileAlongTrack(MultiDimensionReader reader, HashMap metadata, boolean isVertDimAlt) {
+      public ProfileAlongTrack(MultiDimensionReader reader, Map<String, Object> metadata, boolean isVertDimAlt) {
         super(reader, metadata);
         this.isVertDimAlt = isVertDimAlt;
         this.init();
@@ -238,12 +239,12 @@ public abstract class ProfileAlongTrack extends MultiDimensionAdapter {
         return track_tup_idx;
       }
                                                                                                                                                      
-      public Set makeDomain(Object subset) throws Exception {
+      public Set makeDomain(Map<String, double[]> subset) throws Exception {
         double[] first = new double[2];
         double[] last = new double[2];
         int[] length = new int[2];
 
-        HashMap<String, double[]> domainSubset = new HashMap<String, double[]>();
+        Map<String, double[]> domainSubset = new HashMap<>();
         domainSubset.put(trackDim_name, (double[]) ((HashMap)subset).get(trackDim_name));
         domainSubset.put(vertDim_name, (double[]) ((HashMap)subset).get(vertDim_name));
 
@@ -335,8 +336,8 @@ public abstract class ProfileAlongTrack extends MultiDimensionAdapter {
         return domainRealTypes;
       }
 
-      public HashMap getDefaultSubset() {
-        HashMap subset = ProfileAlongTrack.getEmptySubset();
+      public Map<String, double[]> getDefaultSubset() {
+        Map<String, double[]> subset = ProfileAlongTrack.getEmptySubset();
 
         double[] coords = (double[])subset.get("TrackDim");
         coords[0] = 20000.0;
@@ -397,8 +398,8 @@ public abstract class ProfileAlongTrack extends MultiDimensionAdapter {
         return new int[] {low_idx, hi_idx};
       }
 
-      public HashMap getSubsetFromLonLatRect(HashMap subset, double minLat, double maxLat, double minLon, double maxLon) {
-        double[] coords = (double[])subset.get("TrackDim");
+      public Map<String, double[]> getSubsetFromLonLatRect(Map<String, double[]> subset, double minLat, double maxLat, double minLon, double maxLon) {
+        double[] coords = subset.get("TrackDim");
         int[] idxs = getTrackRangeInsideLonLatRect(minLat, maxLat, minLon, maxLon);
         coords[0] = (double) idxs[0];
         coords[1] = (double) idxs[1];
@@ -406,10 +407,10 @@ public abstract class ProfileAlongTrack extends MultiDimensionAdapter {
         return subset;
       }
 
-      public HashMap getSubsetFromLonLatRect(HashMap subset, double minLat, double maxLat, double minLon, double maxLon,
+      public Map<String, double[]> getSubsetFromLonLatRect(Map<String, double[]> subset, double minLat, double maxLat, double minLon, double maxLon,
                                              int xStride, int yStride, int zStride) {
 
-        double[] coords = (double[])subset.get("TrackDim"); 
+        double[] coords = subset.get("TrackDim");
         int[] idxs = getTrackRangeInsideLonLatRect(minLat, maxLat, minLon, maxLon);
         coords[0] = (double) idxs[0];
         coords[1] = (double) idxs[1];
@@ -418,18 +419,18 @@ public abstract class ProfileAlongTrack extends MultiDimensionAdapter {
           coords[2] = xStride;
         }
 
-        coords = (double[])subset.get("VertDim");
+        coords = subset.get("VertDim");
         if (yStride > 0) {
           coords[2] = yStride;
         }
         return subset;
       }
 
-      public HashMap getSubsetFromLonLatRect(double minLat, double maxLat, double minLon, double maxLon) {
+      public Map<String, double[]> getSubsetFromLonLatRect(double minLat, double maxLat, double minLon, double maxLon) {
         return getSubsetFromLonLatRect(getDefaultSubset(), minLat, maxLat, minLon, maxLon);
       }
 
-      public HashMap getSubsetFromLonLatRect(double minLat, double maxLat, double minLon, double maxLon,
+      public Map<String, double[]> getSubsetFromLonLatRect(double minLat, double maxLat, double minLon, double maxLon,
                                              int xStride, int yStride, int zStride) {
 
         return getSubsetFromLonLatRect(getDefaultSubset(), minLat, maxLat, minLon, maxLon, xStride, yStride, zStride);

--- a/edu/wisc/ssec/mcidasv/data/hydra/ProfileAlongTrack3D.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/ProfileAlongTrack3D.java
@@ -28,6 +28,8 @@
 
 package edu.wisc.ssec.mcidasv.data.hydra;
 import java.util.HashMap;
+import java.util.Map;
+
 import visad.Set;
 import visad.RealTupleType;
 import visad.RealType;
@@ -43,7 +45,7 @@ public class ProfileAlongTrack3D extends MultiDimensionAdapter {
 
 
   public ProfileAlongTrack3D(ProfileAlongTrack adapter2D) {
-    super(adapter2D.getReader(), (HashMap) adapter2D.getMetadata());
+    super(adapter2D.getReader(), adapter2D.getMetadata());
     this.adapter2D = adapter2D;
     this.reader = adapter2D.getReader();
     rangeProcessor = adapter2D.getRangeProcessor();
@@ -61,9 +63,9 @@ public class ProfileAlongTrack3D extends MultiDimensionAdapter {
   }
 
 
-  public Set makeDomain(Object subset) throws Exception {
-    double[] vert_coords = (double[]) ((HashMap)subset).get(ProfileAlongTrack.vertDim_name);
-    double[] track_coords = (double[])  ((HashMap)subset).get(ProfileAlongTrack.trackDim_name);
+  public Set makeDomain(Map<String, double[]> subset) throws Exception {
+    double[] vert_coords = subset.get(ProfileAlongTrack.vertDim_name);
+    double[] track_coords = subset.get(ProfileAlongTrack.trackDim_name);
 
     int vert_idx = adapter2D.getVertIdx();
     int track_idx = adapter2D.getTrackIdx();
@@ -71,8 +73,8 @@ public class ProfileAlongTrack3D extends MultiDimensionAdapter {
     float[] lonValues = null;
     float[] latValues = null;
 
-    String lonArrayName = (String) ((HashMap)getMetadata()).get(ProfileAlongTrack.longitude_name);
-    String latArrayName = (String) ((HashMap)getMetadata()).get(ProfileAlongTrack.latitude_name);
+    String lonArrayName = (String)getMetadata().get(ProfileAlongTrack.longitude_name);
+    String latArrayName = (String)getMetadata().get(ProfileAlongTrack.latitude_name);
 
     int[] start = null;
     int[] count = null;
@@ -122,19 +124,19 @@ public class ProfileAlongTrack3D extends MultiDimensionAdapter {
   }
   
 
-  public HashMap getDefaultSubset() {
+  public Map<String, double[]> getDefaultSubset() {
     return adapter2D.getDefaultSubset();
   }
 
-  public HashMap getSubsetFromLonLatRect(HashMap subset, double minLat, double maxLat, double minLon, double maxLon) {
+  public Map<String, double[]> getSubsetFromLonLatRect(Map<String, double[]> subset, double minLat, double maxLat, double minLon, double maxLon) {
     return adapter2D.getSubsetFromLonLatRect(subset, minLat, maxLat, minLon, maxLon);
   }
 
-  public HashMap getSubsetFromLonLatRect(double minLat, double maxLat, double minLon, double maxLon) {
+  public Map<String, double[]> getSubsetFromLonLatRect(double minLat, double maxLat, double minLon, double maxLon) {
     return adapter2D.getSubsetFromLonLatRect(minLat, maxLat, minLon, maxLon);
   }
 
-  public HashMap getSubsetFromLonLatRect(double minLat, double maxLat, double minLon, double maxLon, int xStride, int yStride, int zStride) {
+  public Map<String, double[]> getSubsetFromLonLatRect(double minLat, double maxLat, double minLon, double maxLon, int xStride, int yStride, int zStride) {
     return adapter2D.getSubsetFromLonLatRect(minLat, maxLat, minLon, maxLon, xStride, yStride, zStride);
   }
 

--- a/edu/wisc/ssec/mcidasv/data/hydra/RangeProcessor.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/RangeProcessor.java
@@ -28,7 +28,7 @@
 
 package edu.wisc.ssec.mcidasv.data.hydra;
 
-import java.util.HashMap;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,7 +43,7 @@ public class RangeProcessor {
 			.getLogger(RangeProcessor.class);
 
 	static RangeProcessor createRangeProcessor(MultiDimensionReader reader,
-			HashMap metadata) throws Exception {
+			Map<String, Object> metadata) throws Exception {
 		if (reader instanceof GranuleAggregation) {
 			return new AggregationRangeProcessor((GranuleAggregation) reader,
 					metadata);
@@ -68,7 +68,7 @@ public class RangeProcessor {
 	}
 
 	MultiDimensionReader reader;
-	HashMap metadata;
+	Map<String, Object> metadata;
 
 	float[] scale = null;
 	float[] offset = null;
@@ -104,13 +104,13 @@ public class RangeProcessor {
 		this.valid_high = valid_high;
 	}
 
-	public RangeProcessor(MultiDimensionReader reader, HashMap metadata,
+	public RangeProcessor(MultiDimensionReader reader, Map<String, Object> metadata,
 			String multiScaleDimName) throws Exception {
 		this(reader, metadata);
 		this.multiScaleDimName = multiScaleDimName;
 	}
 
-	public RangeProcessor(MultiDimensionReader reader, HashMap metadata)
+	public RangeProcessor(MultiDimensionReader reader, Map<String, Object> metadata)
 			throws Exception {
 		this.reader = reader;
 		this.metadata = metadata;
@@ -225,7 +225,7 @@ public class RangeProcessor {
 	 *
 	 * @return Processed range.
 	 */
-	public float[] processRangeQualityFlag(byte[] values, HashMap subset,
+	public float[] processRangeQualityFlag(byte[] values, Map subset,
 			QualityFlag qf) {
 
 		if (subset != null) {
@@ -317,7 +317,7 @@ public class RangeProcessor {
 	 *
 	 * @return Processed range.
 	 */
-	public float[] processRange(byte[] values, HashMap subset) {
+	public float[] processRange(byte[] values, Map<String, double[]> subset) {
 
                 int multiScaleDimLen = 1;
 
@@ -415,7 +415,7 @@ public class RangeProcessor {
 	 *
 	 * @return Processed range.
 	 */
-	public float[] processRange(short[] values, HashMap subset) {
+	public float[] processRange(short[] values, Map<String, double[]> subset) {
  
                 int multiScaleDimLen = 1;
 
@@ -514,7 +514,7 @@ public class RangeProcessor {
 	 *
 	 * @return Processed array.
 	 */
-	public float[] processRange(float[] values, HashMap subset) {
+	public float[] processRange(float[] values, Map<String, double[]> subset) {
 
 		float[] new_values = null;
 
@@ -558,7 +558,7 @@ public class RangeProcessor {
 	 *
 	 * @return Processed array.
 	 */
-	public double[] processRange(double[] values, HashMap subset) {
+	public double[] processRange(double[] values, Map<String, double[]> subset) {
 
 		double[] new_values = null;
 

--- a/edu/wisc/ssec/mcidasv/data/hydra/SpectrumAdapter.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/SpectrumAdapter.java
@@ -30,6 +30,8 @@ package edu.wisc.ssec.mcidasv.data.hydra;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import visad.FunctionType;
 import visad.Gridded1DSet;
@@ -58,8 +60,8 @@ public class SpectrumAdapter extends MultiDimensionAdapter {
   public static String bandNames = "bandNames";
 
 
-  public static HashMap getEmptyMetadataTable() {
-    HashMap<String, String> metadata = new HashMap<String, String>();
+  public static Map<String, Object> getEmptyMetadataTable() {
+    Map<String, Object> metadata = new HashMap<>();
     metadata.put(array_name, null);
     metadata.put(range_name, null);
     metadata.put(channelIndex_name, null);
@@ -82,8 +84,8 @@ public class SpectrumAdapter extends MultiDimensionAdapter {
     return metadata;
   }
 
-  public static HashMap<String, double[]> getEmptySubset() {
-    HashMap<String, double[]> subset = new HashMap<String, double[]>();
+  public static Map<String, double[]> getEmptySubset() {
+    Map<String, double[]> subset = new HashMap<>();
     subset.put(x_dim_name, new double[3]);
     subset.put(y_dim_name, new double[3]);
     subset.put(channelIndex_name, new double[3]);
@@ -98,12 +100,12 @@ public class SpectrumAdapter extends MultiDimensionAdapter {
   RealType spectrumRangeType;
   FunctionType spectrumType;
 
-  ArrayList<String> bandNameList = new ArrayList<String>();
+  List<String> bandNameList = new ArrayList<>();
   String[] bandNameArray = null;
-  HashMap<String, Float> bandNameMap = null;
+  Map<String, Float> bandNameMap = null;
   boolean hasBandNames = false;
 
-  public SpectrumAdapter(MultiDimensionReader reader, HashMap metadata) {
+  public SpectrumAdapter(MultiDimensionReader reader, Map<String, Object> metadata) {
     super(reader, metadata);
     this.init();
   }
@@ -145,11 +147,11 @@ public class SpectrumAdapter extends MultiDimensionAdapter {
      return hasBandNames;
   }
 
-  public ArrayList<String> getBandNames() {
+  public List<String> getBandNames() {
     return bandNameList;
   }
 
-  public HashMap<String, Float> getBandNameMap() {
+  public Map<String, Float> getBandNameMap() {
     return bandNameMap;
   }
 
@@ -162,7 +164,7 @@ public class SpectrumAdapter extends MultiDimensionAdapter {
     }
   }
 
-  public Set makeDomain(Object subset) throws Exception {
+  public Set makeDomain(Map<String, double[]> subset) throws Exception {
     return domainSet;
   }
 
@@ -194,7 +196,7 @@ public class SpectrumAdapter extends MultiDimensionAdapter {
     }
 
     if (hasBandNames) {
-      bandNameMap = new HashMap<String, Float>();
+      bandNameMap = new HashMap<>();
       for (int k=0; k<numChannels; k++) {
         bandNameMap.put(bandNameArray[k], new Float(channels[k]));
       }
@@ -232,8 +234,8 @@ public class SpectrumAdapter extends MultiDimensionAdapter {
     return sorted_range;
   }
 
-  public HashMap getDefaultSubset() {
-    HashMap<String, double[]> subset = SpectrumAdapter.getEmptySubset();
+  public Map<String, double[]> getDefaultSubset() {
+    Map<String, double[]> subset = SpectrumAdapter.getEmptySubset();
     
     double[] coords = (double[])subset.get(y_dim_name);
     coords[0] = 1.0;

--- a/edu/wisc/ssec/mcidasv/data/hydra/SuomiNPPDataSource.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/SuomiNPPDataSource.java
@@ -112,8 +112,8 @@ public class SuomiNPPDataSource extends HydraDataSource {
     protected String filename;
     
     // for loading bundles, store granule lists and geo lists here
-    protected List<String> oldSources = new ArrayList<String>();
-    protected List<String> geoSources = new ArrayList<String>();
+    protected List<String> oldSources = new ArrayList<>();
+    protected List<String> geoSources = new ArrayList<>();
     
     // integrity map for grouping sets/aggregations of selected products
     Map<String, List<String>> filenameMap = null;
@@ -122,10 +122,10 @@ public class SuomiNPPDataSource extends HydraDataSource {
 
     protected MultiDimensionAdapter[] adapters = null;
     
-    private ArrayList<MultiSpectralData> msd_CrIS = new ArrayList<MultiSpectralData>();
-    private ArrayList<MultiSpectralData> multiSpectralData = new ArrayList<MultiSpectralData>();
-    private HashMap<String, MultiSpectralData> msdMap = new HashMap<String, MultiSpectralData>();
-    private HashMap<String, QualityFlag> qfMap = new HashMap<String, QualityFlag>();
+    private List<MultiSpectralData> msd_CrIS = new ArrayList<>();
+    private List<MultiSpectralData> multiSpectralData = new ArrayList<>();
+    private Map<String, MultiSpectralData> msdMap = new HashMap<>();
+    private Map<String, QualityFlag> qfMap = new HashMap<>();
 
     private static final String DATA_DESCRIPTION = "Suomi NPP Data";
     
@@ -143,7 +143,7 @@ public class SuomiNPPDataSource extends HydraDataSource {
     // for now, we are only handling OMPS variables that match this filter and SCAN dimensions
     private String ompsFilter = "Radiance";
 
-    private HashMap defaultSubset;
+    private Map<String, double[]> defaultSubset;
     public TrackAdapter track_adapter;
 
     private List categories;
@@ -210,7 +210,7 @@ public class SuomiNPPDataSource extends HydraDataSource {
         setDescription("Suomi NPP");
         
         // build the filename map - matches each product to set of files for that product
-        filenameMap = new HashMap<String, List<String>>();
+        filenameMap = new HashMap<>();
         
         // Pass 1, populate the list of products selected
         for (Object o : sources) {
@@ -278,7 +278,7 @@ public class SuomiNPPDataSource extends HydraDataSource {
     	// looking to populate 3 things - path to lat, path to lon, path to relevant products
     	String pathToLat = null;
     	String pathToLon = null;
-    	LinkedHashSet<String> pathToProducts = new LinkedHashSet<String>();
+    	Set<String> pathToProducts = new LinkedHashSet<>();
     	
     	// flag to indicate data is 3-dimensions (X, Y, channel or band)
     	boolean is3D = false;
@@ -302,14 +302,14 @@ public class SuomiNPPDataSource extends HydraDataSource {
         }
     	
     	// various metatdata we'll need to gather on a per-product basis
-        LinkedHashMap<String, String> unsignedFlags = new LinkedHashMap<String, String>();
-        LinkedHashMap<String, String> unpackFlags = new LinkedHashMap<String, String>();
+        Map<String, String> unsignedFlags = new LinkedHashMap<>();
+        Map<String, String> unpackFlags = new LinkedHashMap<>();
     	
     	// geo product IDs for each granule
-    	LinkedHashSet<String> geoProductIDs = new LinkedHashSet<String>();
+    	Set<String> geoProductIDs = new LinkedHashSet<>();
     	
     	// aggregations will use sets of NetCDFFile readers
-    	ArrayList<NetCDFFile> ncdfal = new ArrayList<NetCDFFile>();
+    	List<NetCDFFile> ncdfal = new ArrayList<>();
     	
     	// we should be able to find an XML Product Profile for each data/product type
     	SuomiNPPProductProfile nppPP = null;
@@ -965,16 +965,16 @@ public class SuomiNPPDataSource extends HydraDataSource {
     	
     	logger.debug("Number of adapters needed: " + pathToProducts.size());
     	adapters = new MultiDimensionAdapter[pathToProducts.size()];
-    	Hashtable<String, String[]> properties = new Hashtable<String, String[]>(); 
+    	Hashtable<String, String[]> properties = new Hashtable<>();
     	
     	Iterator<String> iterator = pathToProducts.iterator();
     	int pIdx = 0;
     	boolean adapterCreated = false;
     	while (iterator.hasNext()) {
-    		String pStr = (String) iterator.next();
+    		String pStr = iterator.next();
     		logger.debug("Working on adapter number " + (pIdx + 1) + ": " + pStr);
-        	HashMap<String, Object> swathTable = SwathAdapter.getEmptyMetadataTable();
-        	HashMap<String, Object> spectTable = SpectrumAdapter.getEmptyMetadataTable();
+        	Map<String, Object> swathTable = SwathAdapter.getEmptyMetadataTable();
+        	Map<String, Object> spectTable = SpectrumAdapter.getEmptyMetadataTable();
         	swathTable.put("array_name", pStr);
         	swathTable.put("lon_array_name", pathToLon);
         	swathTable.put("lat_array_name", pathToLat);
@@ -1403,7 +1403,7 @@ public class SuomiNPPDataSource extends HydraDataSource {
 	/**
 	 * @return the qfMap
 	 */
-	public HashMap<String, QualityFlag> getQfMap() {
+	public Map<String, QualityFlag> getQfMap() {
 		return qfMap;
 	}
 
@@ -1411,7 +1411,7 @@ public class SuomiNPPDataSource extends HydraDataSource {
       filename = name;
     }
 
-    public HashMap getSubsetFromLonLatRect(MultiDimensionSubset select, GeoSelection geoSelection) {
+    public Map<String, double[]> getSubsetFromLonLatRect(MultiDimensionSubset select, GeoSelection geoSelection) {
       GeoLocationInfo ginfo = geoSelection.getBoundingBox();
       return adapters[0].getSubsetFromLonLatRect(select.getSubset(), ginfo.getMinLat(), ginfo.getMaxLat(),
                                         ginfo.getMinLon(), ginfo.getMaxLon());
@@ -1468,7 +1468,7 @@ public class SuomiNPPDataSource extends HydraDataSource {
         adapter = adapters[aIdx];
 
         try {
-            HashMap subset = null;
+            Map<String, double[]> subset = null;
             if (ginfo != null) {
             	subset = adapter.getSubsetFromLonLatRect(ginfo.getMinLat(), ginfo.getMaxLat(),
             			ginfo.getMinLon(), ginfo.getMaxLon(),
@@ -1527,7 +1527,7 @@ public class SuomiNPPDataSource extends HydraDataSource {
         return data;
     }
 
-    protected Data applyProperties(Data data, Hashtable requestProperties, HashMap subset, int adapterIndex) 
+    protected Data applyProperties(Data data, Hashtable requestProperties, Map<String, double[]> subset, int adapterIndex)
           throws VisADException, RemoteException {
       Data new_data = data;
 

--- a/edu/wisc/ssec/mcidasv/data/hydra/SwathAdapter.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/SwathAdapter.java
@@ -29,6 +29,7 @@
 package edu.wisc.ssec.mcidasv.data.hydra;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -107,19 +108,19 @@ public class SwathAdapter extends MultiDimensionAdapter {
       private Linear2DSet swathDomain;
       private Linear2DSet domainSet_save;
 
-      private Object last_subset;
+      private Map<String, double[]> last_subset;
 
       int default_stride = 1;
 
-      public static HashMap getEmptySubset() {
-        HashMap<String, double[]> subset = new HashMap<String, double[]>();
+      public static Map<String, double[]> getEmptySubset() {
+        Map<String, double[]> subset = new HashMap<>();
         subset.put(track_name, new double[3]);
         subset.put(xtrack_name, new double[3]);
         return subset;
       }
 
-      public static HashMap<String, Object> getEmptyMetadataTable() {
-    	  HashMap<String, Object> metadata = new HashMap<String, Object>();
+      public static Map<String, Object> getEmptyMetadataTable() {
+    	  Map<String, Object> metadata = new HashMap<>();
     	  metadata.put(array_name, null);
     	  metadata.put(array_dimension_names, null);
     	  metadata.put(track_name, null);
@@ -147,7 +148,7 @@ public class SwathAdapter extends MultiDimensionAdapter {
 
       }
 
-      public SwathAdapter(MultiDimensionReader reader, HashMap metadata) {
+      public SwathAdapter(MultiDimensionReader reader, Map<String, Object> metadata) {
         super(reader, metadata);
         this.init();
       }
@@ -261,7 +262,7 @@ public class SwathAdapter extends MultiDimensionAdapter {
         XTrackLen = len;
       }
 
-      public Set makeDomain(Object subset) throws Exception {
+      public Set makeDomain(Map<String, double[]> subset) throws Exception {
         if (last_subset != null) {
           if (spatialEquals(last_subset, subset)) return domainSet_save;
         }
@@ -270,9 +271,9 @@ public class SwathAdapter extends MultiDimensionAdapter {
         double[] last = new double[2];
         int[] length = new int[2];
 
-        HashMap<String, double[]> domainSubset = new HashMap<String, double[]>();
-        domainSubset.put(track_name, (double[]) ((HashMap)subset).get(track_name));
-        domainSubset.put(xtrack_name, (double[]) ((HashMap)subset).get(xtrack_name));
+        Map<String, double[]> domainSubset = new HashMap<>();
+        domainSubset.put(track_name, subset.get(track_name));
+        domainSubset.put(xtrack_name, subset.get(xtrack_name));
 
         domainSubset.put(track_name, new double[] {0,0,0});
         domainSubset.put(xtrack_name, new double[] {0,0,0});
@@ -281,7 +282,7 @@ public class SwathAdapter extends MultiDimensionAdapter {
         for (int kk=0; kk<2; kk++) {
           RealType rtype = domainRealTypes[kk];
           String name = rtype.getName();
-          double[] coords = (double[]) ((HashMap)subset).get(name);
+          double[] coords = subset.get(name);
           coords[0] = Math.ceil(coords[0]);
           coords[1] = Math.floor(coords[1]);
           first[kk] = coords[0];
@@ -322,9 +323,9 @@ public class SwathAdapter extends MultiDimensionAdapter {
         return swathDomain;
       }
       
-      public boolean spatialEquals(Object last_subset, Object subset) {
-        double[] last_coords = (double[]) ((HashMap)last_subset).get(track_name);
-        double[] coords = (double[]) ((HashMap)subset).get(track_name);
+      public boolean spatialEquals(Map<String, double[]> last_subset, Map<String, double[]> subset) {
+        double[] last_coords = last_subset.get(track_name);
+        double[] coords = subset.get(track_name);
 
         for (int k=0; k<coords.length; k++) {
           if (coords[k] != last_coords[k]) {
@@ -332,8 +333,8 @@ public class SwathAdapter extends MultiDimensionAdapter {
           }
         }
 
-        last_coords = (double[]) ((HashMap)last_subset).get(xtrack_name);
-        coords = (double[]) ((HashMap)subset).get(xtrack_name);
+        last_coords = last_subset.get(xtrack_name);
+        coords = subset.get(xtrack_name);
 
         for (int k=0; k<coords.length; k++) {
           if (coords[k] != last_coords[k]) { 
@@ -348,16 +349,16 @@ public class SwathAdapter extends MultiDimensionAdapter {
         default_stride = stride;
       }
 
-      public HashMap getDefaultSubset() {
-        HashMap subset = SwathAdapter.getEmptySubset();
+      public Map<String, double[]> getDefaultSubset() {
+        Map<String, double[]> subset = SwathAdapter.getEmptySubset();
 
-        double[] coords = (double[])subset.get("Track");
+        double[] coords = subset.get("Track");
         coords[0] = 0.0;
         coords[1] = TrackLen - 1;
         coords[2] = (double)default_stride;
         subset.put("Track", coords);
 
-        coords = (double[])subset.get("XTrack");
+        coords = subset.get("XTrack");
         coords[0] = 0.0;
         coords[1] = XTrackLen - 1 ;
         coords[2] = (double)default_stride;

--- a/edu/wisc/ssec/mcidasv/data/hydra/SwathNavigation.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/SwathNavigation.java
@@ -29,6 +29,7 @@
 package edu.wisc.ssec.mcidasv.data.hydra;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import visad.CoordinateSystem;
 import visad.Gridded2DDoubleSet;
@@ -42,7 +43,7 @@ public class SwathNavigation implements Navigation  {
     String product_name = null;
     SwathNavigation swathNav = null;
     
-    product_name = (String) ((HashMap)swathAdapter.getMetadata()).get(SwathAdapter.product_name);
+    product_name = (String)swathAdapter.getMetadata().get(SwathAdapter.product_name);
 
     if (product_name == null) {
       swathNav = new SwathNavigation(swathAdapter);
@@ -91,7 +92,7 @@ public class SwathNavigation implements Navigation  {
 
   public SwathNavigation(SwathAdapter swathAdapter) throws Exception {
 
-    HashMap metadata = (HashMap) swathAdapter.getMetadata();
+    Map<String, Object> metadata = swathAdapter.getMetadata();
     reader = swathAdapter.getReader();
     this.swathAdapter = swathAdapter;
     track_idx = swathAdapter.track_idx;
@@ -102,7 +103,7 @@ public class SwathNavigation implements Navigation  {
 
     String[] lon_dim_names = null;
 
-    String[] lonDimNames = (String[]) metadata.get(SwathAdapter.lon_array_dimension_names);  
+    String[] lonDimNames = (String[])metadata.get(SwathAdapter.lon_array_dimension_names);
 
     if (lonDimNames != null) {
       lon_dim_names = lonDimNames;
@@ -119,8 +120,8 @@ public class SwathNavigation implements Navigation  {
     geo_start = new int[numDims];
 
 
-    String geo_track_name = (String) metadata.get(SwathAdapter.geo_track_name);
-    String geo_xtrack_name = (String) metadata.get(SwathAdapter.geo_xtrack_name);
+    String geo_track_name = (String)metadata.get(SwathAdapter.geo_track_name);
+    String geo_xtrack_name = (String)metadata.get(SwathAdapter.geo_xtrack_name);
 
     for (int k=0; k<numDims;k++) {
       if ( geo_track_name.equals(lon_dim_names[k]) ) {
@@ -143,36 +144,36 @@ public class SwathNavigation implements Navigation  {
     geoTrackLen  = lon_dim_lengths[geo_track_idx];
     geoXTrackLen = lon_dim_lengths[geo_xtrack_idx];
 
-    String str = (String) metadata.get(SwathAdapter.geo_track_skip_name);
+    String str = (String)metadata.get(SwathAdapter.geo_track_skip_name);
 
     if (str != null) {
       track_ratio = (float) Double.parseDouble(str);
       ratio = track_ratio;
     }
-    str = (String) metadata.get(SwathAdapter.geo_xtrack_skip_name);
+    str = (String)metadata.get(SwathAdapter.geo_xtrack_skip_name);
     if (str != null) {
       xtrack_ratio = (float) Double.parseDouble(str);
     }
-    str = (String) metadata.get(SwathAdapter.geo_track_offset_name);
+    str = (String)metadata.get(SwathAdapter.geo_track_offset_name);
     if (str != null) {
       track_offset = Double.parseDouble(str);
     }
-    str = (String) metadata.get(SwathAdapter.geo_xtrack_offset_name);
+    str = (String)metadata.get(SwathAdapter.geo_xtrack_offset_name);
     if (str != null) {
       xtrack_offset = Double.parseDouble(str);
     }
 
-    str = (String) metadata.get(SwathAdapter.geo_scale_name);
+    str = (String)metadata.get(SwathAdapter.geo_scale_name);
     if (str != null) {
       scale_name = str;
     }
 
-    str = (String) metadata.get(SwathAdapter.geo_offset_name);
+    str = (String)metadata.get(SwathAdapter.geo_offset_name);
     if (str != null) {
       offset_name = str;
     }
 
-    str = (String) metadata.get(SwathAdapter.geo_fillValue_name);
+    str = (String)metadata.get(SwathAdapter.geo_fillValue_name);
     if (str != null) {
       fillValue_name = str;
     }
@@ -180,12 +181,12 @@ public class SwathNavigation implements Navigation  {
     type = reader.getArrayType(lon_array_name);
   }
 
-  public CoordinateSystem getVisADCoordinateSystem(Linear2DSet domainSet, Object domainSubset) throws Exception
+  public CoordinateSystem getVisADCoordinateSystem(Linear2DSet domainSet, Map<String, double[]> domainSubset) throws Exception
   {
-      Subset select = swathAdapter.getIndexes((HashMap)domainSubset);
+      Subset select = swathAdapter.getIndexes(domainSubset);
 
-      double[] track_coords = (double[]) ((HashMap)domainSubset).get(SwathAdapter.track_name);
-      double[] xtrack_coords = (double[]) ((HashMap)domainSubset).get(SwathAdapter.xtrack_name);
+      double[] track_coords = domainSubset.get(SwathAdapter.track_name);
+      double[] xtrack_coords = domainSubset.get(SwathAdapter.xtrack_name);
       
       int[] stride = new int[numDims];
       stride[geo_track_idx] = (int) track_coords[2];
@@ -298,7 +299,7 @@ public class SwathNavigation implements Navigation  {
     }
     else if (type == Short.TYPE) {
       short[] values = reader.getShortArray(lon_array_name, geo_start, geo_count, geo_stride);
-      HashMap metadata = new HashMap();
+      Map<String, Object> metadata = new HashMap<>();
       metadata.put(SwathAdapter.array_name, lon_array_name);
       metadata.put(SwathAdapter.scale_name, scale_name);
       metadata.put(SwathAdapter.offset_name, offset_name);
@@ -307,7 +308,7 @@ public class SwathNavigation implements Navigation  {
       float[] lonValues = rangeProcessor.processRange(values, null);
       
       values = reader.getShortArray(lat_array_name, geo_start, geo_count, geo_stride);
-      metadata = new HashMap();
+      metadata = new HashMap<>();
       metadata.put(SwathAdapter.array_name, lat_array_name);
       metadata.put(SwathAdapter.scale_name, scale_name);
       metadata.put(SwathAdapter.offset_name, offset_name);

--- a/edu/wisc/ssec/mcidasv/data/hydra/TrackAdapter.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/TrackAdapter.java
@@ -30,6 +30,7 @@ package edu.wisc.ssec.mcidasv.data.hydra;
 
 import java.rmi.RemoteException;
 import java.util.HashMap;
+import java.util.Map;
 
 import visad.FlatField;
 import visad.FunctionType;
@@ -55,30 +56,27 @@ public class TrackAdapter extends MultiDimensionAdapter {
      this.rngAdapter = rangeAdapter;
    }
 
-   public Set makeDomain(Object subset) throws Exception {
+   public Set makeDomain(Map<String, double[]> subset) throws Exception {
      throw new Exception("Unimplemented");
    } 
 
-   public FlatField getData(Object subset) throws VisADException, RemoteException {
-     
-     float[] rngValues = null;
-
-     Set set = trackDomain.makeDomain(subset);
-
-     domainType = ((SetType)set.getType()).getDomain();
+   public FlatField getData(Map<String, double[]> subset) throws VisADException, RemoteException {
 
      try {
-       rngValues = (rngAdapter.getData(subset).getFloats())[0];
-     }
-     catch (Exception e) {
+         float[] rngValues = null;
+         Set set = trackDomain.makeDomain(subset);
+
+         domainType = ((SetType)set.getType()).getDomain();
+
+         rngValues = (rngAdapter.getData(subset).getFloats())[0];
+         FlatField field = new FlatField(new FunctionType(domainType, rngAdapter.getMathType().getRange()), set);
+         field.setSamples(new float[][] {rngValues}, false);
+
+         return field;
+     } catch (Exception e) {
        e.printStackTrace();
        return null;
      }
-
-     FlatField field = new FlatField(new FunctionType(domainType, rngAdapter.getMathType().getRange()), set);
-     field.setSamples(new float[][] {rngValues}, false);
-
-     return field;
    }
 
    public void setName(String name) {
@@ -98,10 +96,10 @@ public class TrackAdapter extends MultiDimensionAdapter {
      listIndex = idx;
    }
 
-   public HashMap getDefaultSubset() {
-     HashMap subset = rngAdapter.getDefaultSubset();
+   public Map<String, double[]> getDefaultSubset() {
+     Map<String, double[]> subset = rngAdapter.getDefaultSubset();
      if (subset.containsKey("VertDim")) {
-       double[] coords = (double[]) ((HashMap)subset).get("VertDim");
+       double[] coords = subset.get("VertDim");
        if (coords != null) {
          coords[0] = listIndex;
          coords[1] = listIndex;
@@ -111,12 +109,12 @@ public class TrackAdapter extends MultiDimensionAdapter {
      return subset;
    }
 
-   public HashMap getSubsetFromLonLatRect(double minLat, double maxLat,
+   public Map<String, double[]> getSubsetFromLonLatRect(double minLat, double maxLat,
                                           double minLon, double maxLon) {
       return trackDomain.getSubsetFromLonLatRect(getDefaultSubset(), minLat, maxLat, minLon, maxLon);
    }
 
-   public HashMap getSubsetFromLonLatRect(double minLat, double maxLat,
+   public Map<String, double[]> getSubsetFromLonLatRect(double minLat, double maxLat,
                                           double minLon, double maxLon,
                                           int xStride, int yStride, int zStride) {
       return trackDomain.getSubsetFromLonLatRect(getDefaultSubset(), minLat, maxLat, minLon, maxLon,

--- a/edu/wisc/ssec/mcidasv/data/hydra/TrackDomain.java
+++ b/edu/wisc/ssec/mcidasv/data/hydra/TrackDomain.java
@@ -30,6 +30,7 @@ package edu.wisc.ssec.mcidasv.data.hydra;
 
 import java.rmi.RemoteException;
 import java.util.HashMap;
+import java.util.Map;
 
 import visad.Gridded2DSet;
 import visad.Gridded3DSet;
@@ -74,15 +75,15 @@ public class TrackDomain extends MultiDimensionAdapter {
      TrackLen = trackLongitude.length;
    }
 
-   public Set makeDomain(Object subset) throws VisADException, RemoteException {
+   public Set makeDomain(Map<String, double[]> subset) throws VisADException, RemoteException {
      
      float[] lonValues = null;
      float[] latValues = null;
      float[] altValues = null;
 
      double[] coords = (double[]) ((HashMap)subset).get("TrackDim");
-     HashMap newSubset = this.getDefaultSubset();
-     double[] newCoords = (double[])newSubset.get("TrackDim");
+     Map<String, double[]> newSubset = this.getDefaultSubset();
+     double[] newCoords = newSubset.get("TrackDim");
      System.arraycopy(coords, 0, newCoords, 0, coords.length);
      subset = newSubset;
 
@@ -169,8 +170,8 @@ public class TrackDomain extends MultiDimensionAdapter {
         return new int[] {low_idx, hi_idx};
    }
 
-   public HashMap getSubsetFromLonLatRect(HashMap subset, double minLat, double maxLat, double minLon, double maxLon) {
-      double[] coords = (double[])subset.get("TrackDim");
+   public Map<String, double[]> getSubsetFromLonLatRect(Map<String, double[]> subset, double minLat, double maxLat, double minLon, double maxLon) {
+      double[] coords = subset.get("TrackDim");
       int[] idxs = getTrackRangeInsideLonLatRect(minLat, maxLat, minLon, maxLon);
       coords[0] = (double) idxs[0];
       coords[1] = (double) idxs[1];
@@ -178,7 +179,7 @@ public class TrackDomain extends MultiDimensionAdapter {
       return subset;
    }
 
-   public HashMap getSubsetFromLonLatRect(HashMap subset, double minLat, double maxLat, double minLon, double maxLon,
+   public Map<String, double[]> getSubsetFromLonLatRect(Map<String, double[]> subset, double minLat, double maxLat, double minLon, double maxLon,
                                           int xStride, int yStride, int zStride) {
       double[] coords = (double[])subset.get("TrackDim");
       int[] idxs = getTrackRangeInsideLonLatRect(minLat, maxLat, minLon, maxLon);
@@ -193,7 +194,7 @@ public class TrackDomain extends MultiDimensionAdapter {
       return subset;
    }
 
-   public HashMap getDefaultSubset() {
+   public Map<String, double[]> getDefaultSubset() {
      return lonAdapter.getDefaultSubset();
    }
 }

--- a/edu/wisc/ssec/mcidasv/display/hydra/MultiSpectralDisplay.java
+++ b/edu/wisc/ssec/mcidasv/display/hydra/MultiSpectralDisplay.java
@@ -162,7 +162,7 @@ public class MultiSpectralDisplay implements DisplayListener {
                         select = (MultiDimensionSubset) table.get(key);
                     }
                 }
-                HashMap subset = select.getSubset();
+                Map<String, double[]> subset = select.getSubset();
                 image = data.getImage(waveNumber, subset);
                 image = changeRangeType(image, uniqueRangeType);
             }
@@ -185,7 +185,7 @@ public class MultiSpectralDisplay implements DisplayListener {
                     select = (MultiDimensionSubset) table.get(key);
                 }
             }
-            HashMap subset = select.getSubset();
+            Map<String, double[]> subset = select.getSubset();
             imageData = data.getImage(channel, subset);
             uniqueRangeType = RealType.getRealType(rangeType.getName()+"_"+cnt++);
             imageData = changeRangeType(imageData, uniqueRangeType);
@@ -297,7 +297,7 @@ public class MultiSpectralDisplay implements DisplayListener {
                     if (bandName == null)
                         return;
 
-                    HashMap<String, Float> bandMap = data.getBandNameMap();
+                    Map<String, Float> bandMap = data.getBandNameMap();
                     if (bandMap == null)
                         return;
 


### PR DESCRIPTION
This ended up touching a bunch of files, but the changes are pretty simplistic. I've tried to get 'em all, but I may have missed a few spots.

* Methods should accept and return `Map`/`List` rather than `HashMap`/`ArrayList`.
* "Subsets" appear to always be `HashMaps` with `String` keys mapped to `double[]` values.
* "Metadata" appear to always be `HashMaps` with `String` keys mapping to `Object` values (can't really be anything else!). Perhaps we can get more funky with generics later.

I'm submitting this as a branch/pullreq because I'm a bit concerned about bundles...but I think the changes are worth getting in front of other sets of eyes.